### PR TITLE
Fabric 1.16.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,20 +2,20 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-	minecraft_version=1.16.1
-	yarn_mappings=1.16.1+build.1
-	loader_version=0.8.8+build.202
+	minecraft_version=1.16.2-rc2
+	yarn_mappings=1.16.2-rc2+build.1
+	loader_version=0.9.1+build.205
 
 # Mod Properties
-	mod_version=1.16.1-0.5
+	mod_version=1.16.2-0.6
 	maven_group=top.theillusivec4.curios
 	archives_base_name=curios-fabric
 
 # Dependencies
-	fabric_version=0.16.0+build.384-1.16.1
+	fabric_version=0.17.1+build.394-1.16
 	fiber_version=0.23.0-SNAPSHOT
-	cca_version=2.4.1
-	rei_version=4.10.4
+	cca_version=2.5.0-nightly.20w30a
+	rei_version=5.2.1
 
 # Curse
 	curse_id=394941

--- a/src/main/java/top/theillusivec4/curios/api/type/component/IRenderableCurio.java
+++ b/src/main/java/top/theillusivec4/curios/api/type/component/IRenderableCurio.java
@@ -117,7 +117,7 @@ public interface IRenderableCurio extends CopyableComponent<IRenderableCurio> {
     public static void followHeadRotations(final LivingEntity livingEntity, ModelPart... parts) {
 
       EntityRenderer<? super LivingEntity> render = MinecraftClient.getInstance()
-          .getEntityRenderManager().getRenderer(livingEntity);
+          .getEntityRenderDispatcher().getRenderer(livingEntity);
 
       if (render instanceof LivingEntityRenderer) {
         @SuppressWarnings("unchecked") LivingEntityRenderer<LivingEntity, EntityModel<LivingEntity>> livingRenderer = (LivingEntityRenderer<LivingEntity, EntityModel<LivingEntity>>) render;
@@ -145,7 +145,7 @@ public interface IRenderableCurio extends CopyableComponent<IRenderableCurio> {
         final BipedEntityModel<LivingEntity>... models) {
 
       EntityRenderer<? super LivingEntity> render = MinecraftClient.getInstance()
-          .getEntityRenderManager().getRenderer(livingEntity);
+          .getEntityRenderDispatcher().getRenderer(livingEntity);
 
       if (render instanceof LivingEntityRenderer) {
         @SuppressWarnings("unchecked") LivingEntityRenderer<LivingEntity, EntityModel<LivingEntity>> livingRenderer = (LivingEntityRenderer<LivingEntity, EntityModel<LivingEntity>>) render;

--- a/src/main/java/top/theillusivec4/curios/client/render/CuriosRenderComponents.java
+++ b/src/main/java/top/theillusivec4/curios/client/render/CuriosRenderComponents.java
@@ -58,7 +58,7 @@ public class CuriosRenderComponents {
                 IRenderableCurio.RenderHelper.translateIfSneaking(matrixStack, livingEntity);
                 IRenderableCurio.RenderHelper.rotateIfSneaking(matrixStack, livingEntity);
                 VertexConsumer consumer = ItemRenderer
-                    .getArmorVertexConsumer(vertexConsumerProvider, model.getLayer(AMULET_TEXTURE),
+                    .getGlintVertexConsumer(vertexConsumerProvider, model.getLayer(AMULET_TEXTURE),
                         false, itemStack.hasGlint());
                 model.render(matrixStack, consumer, light, OverlayTexture.DEFAULT_UV, 1.0F, 1.0F,
                     1.0F, 1.0F);
@@ -77,7 +77,7 @@ public class CuriosRenderComponents {
                   float partialTicks, float ageInTicks, float netHeadYaw, float headPitch) {
                 IRenderableCurio.RenderHelper.followHeadRotations(livingEntity, model.crown);
                 VertexConsumer consumer = ItemRenderer
-                    .getArmorVertexConsumer(vertexConsumerProvider, model.getLayer(CROWN_TEXTURE),
+                    .getGlintVertexConsumer(vertexConsumerProvider, model.getLayer(CROWN_TEXTURE),
                         false, itemStack.hasGlint());
                 model.render(matrixStack, consumer, light, OverlayTexture.DEFAULT_UV, 1.0F, 1.0F,
                     1.0F, 1.0F);
@@ -98,7 +98,7 @@ public class CuriosRenderComponents {
                 model.setAngles(livingEntity, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw,
                     headPitch);
                 VertexConsumer consumer = ItemRenderer
-                    .getArmorVertexConsumer(vertexConsumerProvider,
+                    .getGlintVertexConsumer(vertexConsumerProvider,
                         model.getLayer(KNUCKLES_TEXTURE), false, itemStack.hasGlint());
                 model.render(matrixStack, consumer, light, OverlayTexture.DEFAULT_UV, 1.0F, 1.0F,
                     1.0F, 1.0F);

--- a/src/main/java/top/theillusivec4/curios/common/CuriosHelper.java
+++ b/src/main/java/top/theillusivec4/curios/common/CuriosHelper.java
@@ -74,7 +74,7 @@ public class CuriosHelper implements ICuriosHelper {
   public Set<String> getCurioTags(Item item) {
     List<Identifier> list = Lists.newArrayList();
 
-    for (Entry<Identifier, Tag<Item>> identifierTagEntry : ItemTags.getContainer().getEntries()
+    for (Entry<Identifier, Tag<Item>> identifierTagEntry : ItemTags.getTagGroup().getTags()
         .entrySet()) {
       if ((identifierTagEntry.getValue()).contains(item)) {
         list.add(identifierTagEntry.getKey());

--- a/src/main/java/top/theillusivec4/curios/common/inventory/screen/CuriosScreenHandler.java
+++ b/src/main/java/top/theillusivec4/curios/common/inventory/screen/CuriosScreenHandler.java
@@ -109,7 +109,7 @@ public class CuriosScreenHandler extends CraftingScreenHandler {
     for (n = 0; n < 4; ++n) {
       final EquipmentSlot equipmentSlot = EQUIPMENT_SLOT_ORDER[n];
       this.addSlot(new Slot(playerInventory, 39 - n, 8, 8 + n * 18) {
-        public int getMaxStackAmount() {
+        public int getMaxItemCount() {
           return 1;
         }
 


### PR DESCRIPTION
This is in prepartion of a 1.16.2 stable release tomorrow. Used this to test updating a mod to 1.16.2 so I might as well PR it. Mostly dependency updates and mappings.

Only manual change I did was `ItemTags.getContainer().getEntries()` -> `ItemTags.getTagGroup().getTags()`. Do note that cardinal components 1.16.2 versions seem to be betas right now.