### PR TITLE
Changes REI from ModAPI to modImplemenation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-    modApi "me.shedaniel:RoughlyEnoughItems:${project.rei_version}"
+    modImplemenation "me.shedaniel:RoughlyEnoughItems:${project.rei_version}"
 
     modApi "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-base:${project.cca_version}"
     include "io.github.onyxstudios.Cardinal-Components-API:cardinal-components-base:${project.cca_version}"


### PR DESCRIPTION
You're current use of modAPI is causing it ship with REI built in to your mod, which is using an older version which crashes on the 1.16.3.