### PR TITLE
Small fix, some new functionality and localization update

### DIFF
--- a/src/main/java/top/theillusivec4/curios/Curios.java
+++ b/src/main/java/top/theillusivec4/curios/Curios.java
@@ -23,6 +23,8 @@ import com.electronwill.nightconfig.core.CommentedConfig;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ScreenManager;
 import net.minecraft.client.renderer.entity.PlayerRenderer;
@@ -72,6 +74,7 @@ import top.theillusivec4.curios.common.capability.CurioItemCapability;
 import top.theillusivec4.curios.common.event.CuriosEventHandler;
 import top.theillusivec4.curios.common.network.NetworkHandler;
 import top.theillusivec4.curios.common.slottype.SlotTypeManager;
+import top.theillusivec4.curios.common.triggers.EquipCurioTrigger;
 import top.theillusivec4.curios.server.SlotHelper;
 import top.theillusivec4.curios.server.command.CurioArgumentType;
 import top.theillusivec4.curios.server.command.CuriosCommand;
@@ -105,6 +108,8 @@ public class Curios {
     NetworkHandler.register();
     ArgumentTypes.register("curios:slot_type", CurioArgumentType.class,
         new ArgumentSerializer<>(CurioArgumentType::slot));
+    
+    CriteriaTriggers.register(EquipCurioTrigger.INSTANCE);
   }
 
   private void enqueue(InterModEnqueueEvent evt) {

--- a/src/main/java/top/theillusivec4/curios/api/type/capability/ICurio.java
+++ b/src/main/java/top/theillusivec4/curios/api/type/capability/ICurio.java
@@ -31,6 +31,8 @@ import net.minecraft.client.renderer.entity.LivingRenderer;
 import net.minecraft.client.renderer.entity.model.BipedModel;
 import net.minecraft.client.renderer.entity.model.EntityModel;
 import net.minecraft.client.renderer.model.ModelRenderer;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.enchantment.Enchantments;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.ai.attributes.Attribute;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
@@ -262,6 +264,34 @@ public interface ICurio {
    */
   default boolean showAttributesTooltip(String identifier) {
     return false;
+  }
+
+  /**
+   * Allows to set the amount of bonus Fortune levels that are provided by curio.
+   * Default implementation returns level of Fortune enchantment on ItemStack.
+   *
+   * @param identifier   The identifier of the {@link ISlotType} of the slot
+   * @param curio	ItemStack that is checked
+   * @param index        The index of the slot
+   * @param livingEntity The LivingEntity that is wearing the ItemStack
+   * @return Amount of additional Fortune levels that will be applied when mining
+   */
+  default int getFortuneBonus(String identifier, LivingEntity livingEntity, ItemStack curio, int index) {
+    return EnchantmentHelper.getEnchantmentLevel(Enchantments.FORTUNE, curio);
+  }
+
+  /**
+   * Allows to set the amount of bonus Looting levels that are provided by curio.
+   * Default implementation returns level of Looting enchantment on ItemStack.
+   *
+   * @param identifier   The identifier of the {@link ISlotType} of the slot
+   * @param curio	ItemStack that is checked
+   * @param index        The index of the slot
+   * @param livingEntity The LivingEntity that is wearing the ItemStack
+   * @return Amount of additional Looting levels that will be applied in LootingLevelEvent
+   */
+  default int getLootingBonus(String identifier, LivingEntity livingEntity, ItemStack curio, int index) {
+    return EnchantmentHelper.getEnchantmentLevel(Enchantments.LOOTING, curio);
   }
 
   /**

--- a/src/main/java/top/theillusivec4/curios/api/type/capability/ICurio.java
+++ b/src/main/java/top/theillusivec4/curios/api/type/capability/ICurio.java
@@ -63,18 +63,18 @@ public interface ICurio {
       }
 
       for (int i = 0; i < 5; ++i) {
-        Vector3d vec3d = new Vector3d(((double) livingEntity.getRNG().nextFloat() - 0.5D) * 0.1D,
+        Vector3d vec3d = new Vector3d((livingEntity.getRNG().nextFloat() - 0.5D) * 0.1D,
             Math.random() * 0.1D + 0.1D, 0.0D);
         vec3d = vec3d.rotatePitch(-livingEntity.rotationPitch * ((float) Math.PI / 180F));
         vec3d = vec3d.rotateYaw(-livingEntity.rotationYaw * ((float) Math.PI / 180F));
-        double d0 = (double) (-livingEntity.getRNG().nextFloat()) * 0.6D - 0.3D;
+        double d0 = (-livingEntity.getRNG().nextFloat()) * 0.6D - 0.3D;
 
-        Vector3d vec3d1 = new Vector3d(((double) livingEntity.getRNG().nextFloat() - 0.5D) * 0.3D,
+        Vector3d vec3d1 = new Vector3d((livingEntity.getRNG().nextFloat() - 0.5D) * 0.3D,
             d0, 0.6D);
         vec3d1 = vec3d1.rotatePitch(-livingEntity.rotationPitch * ((float) Math.PI / 180F));
         vec3d1 = vec3d1.rotateYaw(-livingEntity.rotationYaw * ((float) Math.PI / 180F));
         vec3d1 = vec3d1.add(livingEntity.getPosX(),
-            livingEntity.getPosY() + (double) livingEntity.getEyeHeight(), livingEntity.getPosZ());
+            livingEntity.getPosY() + livingEntity.getEyeHeight(), livingEntity.getPosZ());
 
         livingEntity.world
             .addParticle(new ItemParticleData(ParticleTypes.ITEM, stack), vec3d1.x, vec3d1.y,
@@ -251,6 +251,17 @@ public interface ICurio {
   @Nonnull
   default DropRule getDropRule(LivingEntity livingEntity) {
     return DropRule.DEFAULT;
+  }
+
+  /**
+   * Determines whether or not Curios will automatically add tooltip listing attribute modifiers
+   * that are returned by {@link ICurio#getAttributeModifiers(String)}.
+   *
+   * @param identifier   The identifier of the {@link ISlotType} of the slot
+   * @return True to show attributes tooltip, false to disable
+   */
+  default boolean showAttributesTooltip(String identifier) {
+    return false;
   }
 
   /**

--- a/src/main/java/top/theillusivec4/curios/api/type/capability/ICurio.java
+++ b/src/main/java/top/theillusivec4/curios/api/type/capability/ICurio.java
@@ -263,7 +263,7 @@ public interface ICurio {
    * @return True to show attributes tooltip, false to disable
    */
   default boolean showAttributesTooltip(String identifier) {
-    return false;
+    return true;
   }
 
   /**

--- a/src/main/java/top/theillusivec4/curios/api/type/capability/ICuriosItemHandler.java
+++ b/src/main/java/top/theillusivec4/curios/api/type/capability/ICuriosItemHandler.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.Set;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.Tuple;
 import top.theillusivec4.curios.api.type.ISlotType;
 import top.theillusivec4.curios.api.type.inventory.ICurioStacksHandler;
 
@@ -134,4 +135,23 @@ public interface ICuriosItemHandler {
    * disabling/removing slots.
    */
   void handleInvalidStacks();
+  
+  /**
+   * Returns the total Fortune bonus of all equipped curios.
+   * Recalculated with each LivingUpdateEvent.
+   */
+  int getFortuneBonus();
+  
+  /**
+   * Returns the total Looting bonus of all equipped curios.
+   * Recalculated with each LivingUpdateEvent.
+   */
+  int getLootingBonus();
+  
+  
+  /**
+   * Sets the total Fotrune and Looting bonuses of this handler and therefore it's bearer.
+   */
+  void setEnchantmentBonuses(Tuple<Integer, Integer> fortuneAndLooting);
+  
 }

--- a/src/main/java/top/theillusivec4/curios/client/ClientEventHandler.java
+++ b/src/main/java/top/theillusivec4/curios/client/ClientEventHandler.java
@@ -62,9 +62,8 @@ public class ClientEventHandler {
   @SubscribeEvent
   public void onKeyInput(TickEvent.ClientTickEvent evt) {
 
-    if (evt.phase != TickEvent.Phase.END) {
-      return;
-    }
+    if (evt.phase != TickEvent.Phase.END)
+		return;
 
     Minecraft mc = Minecraft.getInstance();
 
@@ -116,17 +115,26 @@ public class ClientEventHandler {
           if (!curioTagsTooltip.isEmpty()) {
             tooltip.addAll(1, curio.getTagsTooltip(tagTooltips));
           }
+          
         });
 
         if (!optionalCurio.isPresent()) {
           tooltip.addAll(1, tagTooltips);
         }
 
+
+        
         for (String identifier : slots) {
           Multimap<Attribute, AttributeModifier> multimap = CuriosApi.getCuriosHelper()
               .getAttributeModifiers(identifier, stack);
+          boolean addAttributeTooltips = true;
+          
+          if (optionalCurio.isPresent()) {
+        	  ICurio curio = optionalCurio.orElse(null);
+        	  addAttributeTooltips = curio.showAttributesTooltip(identifier);
+          }
 
-          if (!multimap.isEmpty() && (i & 2) == 0) {
+          if (addAttributeTooltips && !multimap.isEmpty() && (i & 2) == 0) {
             PlayerEntity player = evt.getPlayer();
             tooltip.add(StringTextComponent.EMPTY);
             tooltip.add(new TranslationTextComponent("curios.modifiers." + identifier)
@@ -145,7 +153,7 @@ public class ClientEventHandler {
                   if (att != null) {
                     amount = amount + att.getBaseValue();
                   }
-                  amount = amount + (double) EnchantmentHelper
+                  amount = amount + EnchantmentHelper
                       .getModifierForCreature(stack, CreatureAttribute.UNDEFINED);
                   flag = true;
                 } else if (attributemodifier.getID() == ATTACK_SPEED_MODIFIER) {

--- a/src/main/java/top/theillusivec4/curios/client/gui/CuriosScreen.java
+++ b/src/main/java/top/theillusivec4/curios/client/gui/CuriosScreen.java
@@ -105,20 +105,20 @@ public class CuriosScreen extends ContainerScreen<CuriosContainer> implements IR
     if (this.minecraft != null) {
 
       if (this.minecraft.player != null) {
-        hasScrollBar = CuriosApi.getCuriosHelper().getCuriosHandler(this.minecraft.player)
+        this.hasScrollBar = CuriosApi.getCuriosHelper().getCuriosHandler(this.minecraft.player)
             .map(handler -> handler.getVisibleSlots() > 8).orElse(false);
 
-        if (hasScrollBar) {
+        if (this.hasScrollBar) {
           this.container.scrollTo(currentScroll);
         }
       }
       int neededWidth = 431;
 
-      if (hasScrollBar) {
+      if (this.hasScrollBar) {
         neededWidth += 30;
       }
 
-      if (container.hasCosmeticColumn()) {
+      if (this.container.hasCosmeticColumn()) {
         neededWidth += 40;
       }
       this.widthTooNarrow = this.width < neededWidth;
@@ -127,6 +127,23 @@ public class CuriosScreen extends ContainerScreen<CuriosContainer> implements IR
       this.updateScreenPosition();
       this.children.add(this.recipeBookGui);
       this.setFocusedDefault(this.recipeBookGui);
+      
+      /**
+       * This may not be a perfect workaround as it doesn't return the book upon switching back
+       * to survival mode. Creative inventory doesn't have this problem because it doesn't have
+       * recipe book at all, but here we only have one Screen and must toggle it circumstantially,
+       * and sadly Curios' recipe book isn't and must not be an independent object. I can't think
+       * of better implementation at the moment though.
+       * 
+       * Anyhow, this is better than letting the book persist in creative without a way to toggle it.
+       * @author Extegral
+       */
+      
+      if (this.getMinecraft().player.isCreative() && this.recipeBookGui.isVisible()) {
+      	this.recipeBookGui.toggleVisibility();
+      	this.updateScreenPosition();
+      }
+      
       Tuple<Integer, Integer> offsets = getButtonOffset(false);
       this.buttonCurios = new CuriosButton(this, this.getGuiLeft() + offsets.getA(),
           this.height / 2 + offsets.getB(), 14, 14, 50, 0, 14, CURIO_INVENTORY);
@@ -143,6 +160,7 @@ public class CuriosScreen extends ContainerScreen<CuriosContainer> implements IR
               .setPosition(this.guiLeft + offsets.getA(), this.height / 2 + offsets.getB());
         }));
       }
+      
       this.updateRenderButtons();
     }
   }
@@ -170,11 +188,11 @@ public class CuriosScreen extends ContainerScreen<CuriosContainer> implements IR
     if (this.recipeBookGui.isVisible() && !this.widthTooNarrow) {
       int offset = 148;
 
-      if (hasScrollBar) {
+      if (this.hasScrollBar) {
         offset -= 30;
       }
 
-      if (container.hasCosmeticColumn()) {
+      if (this.container.hasCosmeticColumn()) {
         offset -= 40;
       }
       i = 177 + (this.width - this.xSize - offset) / 2;
@@ -203,8 +221,8 @@ public class CuriosScreen extends ContainerScreen<CuriosContainer> implements IR
       i1 -= 19;
       k -= 19;
     }
-    return mouseX >= (double) k && mouseY >= (double) l && mouseX < (double) i1
-        && mouseY < (double) j1;
+    return mouseX >= k && mouseY >= l && mouseX < i1
+        && mouseY < j1;
   }
 
   @Override
@@ -282,9 +300,8 @@ public class CuriosScreen extends ContainerScreen<CuriosContainer> implements IR
         playerEntity.closeScreen();
       }
       return true;
-    } else {
-      return super.keyPressed(p_keyPressed_1_, p_keyPressed_2_, p_keyPressed_3_);
-    }
+    } else
+		return super.keyPressed(p_keyPressed_1_, p_keyPressed_2_, p_keyPressed_3_);
   }
 
   @Override
@@ -361,9 +378,8 @@ public class CuriosScreen extends ContainerScreen<CuriosContainer> implements IR
   protected boolean isPointInRegion(int rectX, int rectY, int rectWidth, int rectHeight,
       double pointX, double pointY) {
 
-    if (isRenderButtonHovered) {
-      return false;
-    }
+    if (this.isRenderButtonHovered)
+		return false;
     return (!this.widthTooNarrow || !this.recipeBookGui.isVisible()) && super
         .isPointInRegion(rectX, rectY, rectWidth, rectHeight, pointX, pointY);
   }
@@ -374,9 +390,9 @@ public class CuriosScreen extends ContainerScreen<CuriosContainer> implements IR
   @Override
   public boolean mouseClicked(double mouseX, double mouseY, int mouseButton) {
 
-    if (this.recipeBookGui.mouseClicked(mouseX, mouseY, mouseButton)) {
-      return true;
-    } else if (this.inScrollBar(mouseX, mouseY)) {
+    if (this.recipeBookGui.mouseClicked(mouseX, mouseY, mouseButton))
+		return true;
+	else if (this.inScrollBar(mouseX, mouseY)) {
       this.isScrolling = this.needsScrollBars();
       return true;
     }
@@ -394,9 +410,8 @@ public class CuriosScreen extends ContainerScreen<CuriosContainer> implements IR
     if (this.buttonClicked) {
       this.buttonClicked = false;
       return true;
-    } else {
-      return super.mouseReleased(mouseReleased1, mouseReleased3, mouseReleased5);
-    }
+    } else
+		return super.mouseReleased(mouseReleased1, mouseReleased3, mouseReleased5);
   }
 
   @Override
@@ -406,25 +421,24 @@ public class CuriosScreen extends ContainerScreen<CuriosContainer> implements IR
     if (this.isScrolling) {
       int i = this.guiTop + 8;
       int j = i + 148;
-      currentScroll = ((float) pMouseDragged3 - (float) i - 7.5F) / ((float) (j - i) - 15.0F);
+      currentScroll = ((float) pMouseDragged3 - i - 7.5F) / (j - i - 15.0F);
       currentScroll = MathHelper.clamp(currentScroll, 0.0F, 1.0F);
       this.container.scrollTo(currentScroll);
       return true;
-    } else {
-      return super.mouseDragged(pMouseDragged1, pMouseDragged3, pMouseDragged5, pMouseDragged6,
-          pMouseDragged8);
-    }
+    } else
+		return super.mouseDragged(pMouseDragged1, pMouseDragged3, pMouseDragged5, pMouseDragged6,
+		      pMouseDragged8);
   }
 
   @Override
   public boolean mouseScrolled(double pMouseScrolled1, double pMouseScrolled3,
       double pMouseScrolled5) {
 
-    if (!this.needsScrollBars()) {
-      return false;
-    } else {
+    if (!this.needsScrollBars())
+		return false;
+	else {
       int i = (this.container).curiosHandler.map(ICuriosItemHandler::getVisibleSlots).orElse(1);
-      currentScroll = (float) ((double) currentScroll - pMouseScrolled5 / (double) i);
+      currentScroll = (float) (currentScroll - pMouseScrolled5 / i);
       currentScroll = MathHelper.clamp(currentScroll, 0.0F, 1.0F);
       this.container.scrollTo(currentScroll);
       return true;
@@ -438,8 +452,8 @@ public class CuriosScreen extends ContainerScreen<CuriosContainer> implements IR
   protected boolean hasClickedOutside(double mouseX, double mouseY, int guiLeftIn, int guiTopIn,
       int mouseButton) {
     boolean flag =
-        mouseX < (double) guiLeftIn || mouseY < (double) guiTopIn || mouseX >= (double) (guiLeftIn
-            + this.xSize) || mouseY >= (double) (guiTopIn + this.ySize);
+        mouseX < guiLeftIn || mouseY < guiTopIn || mouseX >= guiLeftIn
+            + this.xSize || mouseY >= guiTopIn + this.ySize;
     return this.recipeBookGui
         .func_195604_a(mouseX, mouseY, this.guiLeft, this.guiTop, this.xSize, this.ySize,
             mouseButton) && flag;

--- a/src/main/java/top/theillusivec4/curios/common/CuriosRegistry.java
+++ b/src/main/java/top/theillusivec4/curios/common/CuriosRegistry.java
@@ -21,10 +21,13 @@ package top.theillusivec4.curios.common;
 
 import net.minecraft.inventory.container.ContainerType;
 import net.minecraft.item.Item;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.extensions.IForgeContainerType;
+import net.minecraftforge.common.loot.GlobalLootModifierSerializer;
 import net.minecraftforge.event.RegistryEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.registries.IForgeRegistry;
 import net.minecraftforge.registries.ObjectHolder;
 import top.theillusivec4.curios.Curios;
 import top.theillusivec4.curios.common.inventory.container.CuriosContainer;
@@ -32,6 +35,7 @@ import top.theillusivec4.curios.common.item.AmuletItem;
 import top.theillusivec4.curios.common.item.CrownItem;
 import top.theillusivec4.curios.common.item.KnucklesItem;
 import top.theillusivec4.curios.common.item.RingItem;
+import top.theillusivec4.curios.common.objects.FortuneBonusModifier;
 
 @Mod.EventBusSubscriber(modid = Curios.MODID, bus = Mod.EventBusSubscriber.Bus.MOD)
 public class CuriosRegistry {
@@ -69,5 +73,13 @@ public class CuriosRegistry {
   public static void registerContainer(RegistryEvent.Register<ContainerType<?>> evt) {
     evt.getRegistry().register(
         IForgeContainerType.create(CuriosContainer::new).setRegistryName("curios_container"));
+  }
+  
+  @SubscribeEvent
+  public static void registerLootModifiers(final RegistryEvent.Register<GlobalLootModifierSerializer<?>> event) {
+	  final IForgeRegistry<GlobalLootModifierSerializer<?>> registry = event.getRegistry();
+	  
+	  registry.register(
+			new FortuneBonusModifier.Serializer().setRegistryName(new ResourceLocation(Curios.MODID, "fortune_bonus")));
   }
 }

--- a/src/main/java/top/theillusivec4/curios/common/event/CuriosEventHandler.java
+++ b/src/main/java/top/theillusivec4/curios/common/event/CuriosEventHandler.java
@@ -224,11 +224,11 @@ public class CuriosEventHandler {
           CuriosApi.getCuriosHelper().getCurio(stack)
               .ifPresent(curio -> { 
             	  curio.onEquip(identifier, index, player);
-            	  
-            	  if (player instanceof ServerPlayerEntity) {
-					EquipCurioTrigger.INSTANCE.trigger((ServerPlayerEntity)player, stack, (ServerWorld)player.world, player.getPosX(), player.getPosY(), player.getPosZ());
-            	  }
               });
+          
+          if (player instanceof ServerPlayerEntity) {
+				EquipCurioTrigger.INSTANCE.trigger((ServerPlayerEntity)player, stack, (ServerWorld)player.world, player.getPosX(), player.getPosY(), player.getPosZ());
+      	  }
         }
       });
     }));
@@ -376,11 +376,12 @@ public class CuriosEventHandler {
               prevCurio.ifPresent(curio -> curio.onUnequip(identifier, index, livingEntity));
               currentCurio.ifPresent(curio -> { 
             	  curio.onEquip(identifier, index, livingEntity);
-            	  
-            	  if (livingEntity instanceof ServerPlayerEntity) {
-					EquipCurioTrigger.INSTANCE.trigger((ServerPlayerEntity)livingEntity, stack, (ServerWorld)livingEntity.world, livingEntity.getPosX(), livingEntity.getPosY(), livingEntity.getPosZ());
-            	  }
               });
+              
+              if (livingEntity instanceof ServerPlayerEntity) {
+					EquipCurioTrigger.INSTANCE.trigger((ServerPlayerEntity)livingEntity, stack, (ServerWorld)livingEntity.world, livingEntity.getPosX(), livingEntity.getPosY(), livingEntity.getPosZ());
+          	  }
+              
               stackHandler
                   .setPreviousStackInSlot(i, stack.isEmpty() ? ItemStack.EMPTY : stack.copy());
             }

--- a/src/main/java/top/theillusivec4/curios/common/event/CuriosEventHandler.java
+++ b/src/main/java/top/theillusivec4/curios/common/event/CuriosEventHandler.java
@@ -42,6 +42,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Tuple;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.GameRules;
+import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
@@ -72,6 +73,7 @@ import top.theillusivec4.curios.common.network.server.SPacketSetIcons;
 import top.theillusivec4.curios.common.network.server.sync.SPacketSyncCurios;
 import top.theillusivec4.curios.common.network.server.sync.SPacketSyncStack;
 import top.theillusivec4.curios.common.network.server.sync.SPacketSyncStack.HandlerType;
+import top.theillusivec4.curios.common.triggers.EquipCurioTrigger;
 
 public class CuriosEventHandler {
 
@@ -108,7 +110,7 @@ public class CuriosEventHandler {
 
   private static ItemEntity getDroppedItem(ItemStack droppedItem, LivingEntity livingEntity) {
     double d0 =
-        livingEntity.getPosY() - 0.30000001192092896D + (double) livingEntity.getEyeHeight();
+        livingEntity.getPosY() - 0.30000001192092896D + livingEntity.getEyeHeight();
     ItemEntity entityitem = new ItemEntity(livingEntity.world, livingEntity.getPosX(), d0,
         livingEntity.getPosZ(), droppedItem);
     entityitem.setPickupDelay(40);
@@ -220,7 +222,13 @@ public class CuriosEventHandler {
               CuriosApi.getCuriosHelper().getAttributeModifiers(identifier, stack));
           int index = i;
           CuriosApi.getCuriosHelper().getCurio(stack)
-              .ifPresent(curio -> curio.onEquip(identifier, index, player));
+              .ifPresent(curio -> { 
+            	  curio.onEquip(identifier, index, player);
+            	  
+            	  if (player instanceof ServerPlayerEntity) {
+					EquipCurioTrigger.INSTANCE.trigger((ServerPlayerEntity)player, stack, (ServerWorld)player.world, player.getPosX(), player.getPosY(), player.getPosZ());
+            	  }
+              });
         }
       });
     }));
@@ -272,9 +280,8 @@ public class CuriosEventHandler {
         for (ICurioStacksHandler stacksHandler : curios.values()) {
 
           if (handleMending(player, stacksHandler.getStacks(), evt) || handleMending(player,
-              stacksHandler.getCosmeticStacks(), evt)) {
-            return;
-          }
+              stacksHandler.getCosmeticStacks(), evt))
+			return;
         }
       });
     }
@@ -367,7 +374,13 @@ public class CuriosEventHandler {
               livingEntity.getAttributeManager().reapplyModifiers(
                   CuriosApi.getCuriosHelper().getAttributeModifiers(identifier, stack));
               prevCurio.ifPresent(curio -> curio.onUnequip(identifier, index, livingEntity));
-              currentCurio.ifPresent(curio -> curio.onEquip(identifier, index, livingEntity));
+              currentCurio.ifPresent(curio -> { 
+            	  curio.onEquip(identifier, index, livingEntity);
+            	  
+            	  if (livingEntity instanceof ServerPlayerEntity) {
+					EquipCurioTrigger.INSTANCE.trigger((ServerPlayerEntity)livingEntity, stack, (ServerWorld)livingEntity.world, livingEntity.getPosX(), livingEntity.getPosY(), livingEntity.getPosZ());
+            	  }
+              });
               stackHandler
                   .setPreviousStackInSlot(i, stack.isEmpty() ? ItemStack.EMPTY : stack.copy());
             }

--- a/src/main/java/top/theillusivec4/curios/common/event/CuriosEventHandler.java
+++ b/src/main/java/top/theillusivec4/curios/common/event/CuriosEventHandler.java
@@ -357,8 +357,6 @@ public class CuriosEventHandler {
 							if (!living.world.isRemote && !stack.isEmpty()) {
 								if (curioCapability.isPresent()) {
 									totalLootingBonus += curioCapability.orElseGet(null).getLootingBonus(identifier, living, stack, index);
-								} else {
-									totalLootingBonus += EnchantmentHelper.getEnchantmentLevel(Enchantments.LOOTING, stack);
 								}
 							}
 						}

--- a/src/main/java/top/theillusivec4/curios/common/objects/FortuneBonusModifier.java
+++ b/src/main/java/top/theillusivec4/curios/common/objects/FortuneBonusModifier.java
@@ -1,0 +1,105 @@
+package top.theillusivec4.curios.common.objects;
+
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.JsonObject;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.enchantment.Enchantments;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.loot.LootContext;
+import net.minecraft.loot.LootParameterSets;
+import net.minecraft.loot.LootParameters;
+import net.minecraft.loot.LootTable;
+import net.minecraft.loot.conditions.ILootCondition;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.loot.GlobalLootModifierSerializer;
+import net.minecraftforge.common.loot.LootModifier;
+import net.minecraftforge.common.util.LazyOptional;
+import top.theillusivec4.curios.api.CuriosApi;
+import top.theillusivec4.curios.api.type.capability.ICurio;
+import top.theillusivec4.curios.api.type.capability.ICuriosItemHandler;
+import top.theillusivec4.curios.api.type.inventory.ICurioStacksHandler;
+import top.theillusivec4.curios.api.type.inventory.IDynamicStackHandler;
+
+public class FortuneBonusModifier extends LootModifier {
+
+	protected FortuneBonusModifier(ILootCondition[] conditions) {
+		super(conditions);
+	}
+
+	@Override
+	protected List<ItemStack> doApply(List<ItemStack> generatedLoot, LootContext context) {
+		ItemStack tool = context.get(LootParameters.TOOL);
+
+		if (tool == null || tool.getOrCreateTag().getBoolean("HasCuriosFortuneBonus"))
+			return generatedLoot;
+
+		Entity entity = context.get(LootParameters.THIS_ENTITY);
+		BlockState blockState = context.get(LootParameters.BLOCK_STATE);
+		if (blockState == null || !(entity instanceof LivingEntity))
+			return generatedLoot;
+
+		LivingEntity player = (LivingEntity) entity;
+		int totalFortuneBonus = 0;
+
+		if (CuriosApi.getCuriosHelper().getCuriosHandler(player).isPresent()) {
+			ICuriosItemHandler handler = CuriosApi.getCuriosHelper().getCuriosHandler(player).orElse(null);
+			Map<String, ICurioStacksHandler> curios = handler.getCurios();
+			
+			for (Map.Entry<String, ICurioStacksHandler> entry : curios.entrySet()) {
+				ICurioStacksHandler stacksHandler = entry.getValue();
+				String identifier = entry.getKey();
+				IDynamicStackHandler stackHandler = stacksHandler.getStacks();
+
+				for (int i = 0; i < stackHandler.getSlots(); i++) {
+					ItemStack stack = stackHandler.getStackInSlot(i);
+					LazyOptional<ICurio> curioCapability = CuriosApi.getCuriosHelper().getCurio(stack);
+					final int index = i;
+
+					if (!player.world.isRemote && !stack.isEmpty()) {
+						if (curioCapability.isPresent()) {
+							totalFortuneBonus += curioCapability.orElseGet(null).getFortuneBonus(identifier, player, stack, index);
+						} else {
+							totalFortuneBonus += EnchantmentHelper.getEnchantmentLevel(Enchantments.FORTUNE, stack);
+						}
+					}
+				}
+			}
+		}
+
+		if (totalFortuneBonus <= 0)
+			return generatedLoot;
+
+		ItemStack fakeTool = tool.isEmpty() ? new ItemStack(Items.BARRIER) : tool.copy();
+		fakeTool.getOrCreateTag().putBoolean("HasCuriosFortuneBonus", true);
+
+		Map<Enchantment, Integer> enchantments = EnchantmentHelper.getEnchantments(fakeTool);
+		enchantments.put(Enchantments.FORTUNE, EnchantmentHelper.getEnchantmentLevel(Enchantments.FORTUNE, fakeTool) + totalFortuneBonus);
+		EnchantmentHelper.setEnchantments(enchantments, fakeTool);
+		LootContext.Builder builder = new LootContext.Builder(context);
+		builder.withParameter(LootParameters.TOOL, fakeTool);
+		LootContext newContext = builder.build(LootParameterSets.BLOCK);
+		LootTable lootTable = context.getWorld().getServer().getLootTableManager().getLootTableFromLocation(blockState.getBlock().getLootTable());
+		return lootTable.generate(newContext);
+	}
+
+	public static class Serializer extends GlobalLootModifierSerializer<FortuneBonusModifier> {
+
+		@Override
+		public FortuneBonusModifier read(ResourceLocation location, JsonObject object, ILootCondition[] conditions) {
+			return new FortuneBonusModifier(conditions);
+		}
+
+		@Override
+		public JsonObject write(FortuneBonusModifier instance) {
+			return this.makeConditions(instance.conditions);
+		}
+	}
+}

--- a/src/main/java/top/theillusivec4/curios/common/objects/FortuneBonusModifier.java
+++ b/src/main/java/top/theillusivec4/curios/common/objects/FortuneBonusModifier.java
@@ -50,26 +50,7 @@ public class FortuneBonusModifier extends LootModifier {
 		int totalFortuneBonus = 0;
 
 		if (CuriosApi.getCuriosHelper().getCuriosHandler(player).isPresent()) {
-			ICuriosItemHandler handler = CuriosApi.getCuriosHelper().getCuriosHandler(player).orElse(null);
-			Map<String, ICurioStacksHandler> curios = handler.getCurios();
-			
-			for (Map.Entry<String, ICurioStacksHandler> entry : curios.entrySet()) {
-				ICurioStacksHandler stacksHandler = entry.getValue();
-				String identifier = entry.getKey();
-				IDynamicStackHandler stackHandler = stacksHandler.getStacks();
-
-				for (int i = 0; i < stackHandler.getSlots(); i++) {
-					ItemStack stack = stackHandler.getStackInSlot(i);
-					LazyOptional<ICurio> curioCapability = CuriosApi.getCuriosHelper().getCurio(stack);
-					final int index = i;
-
-					if (!player.world.isRemote && !stack.isEmpty()) {
-						if (curioCapability.isPresent()) {
-							totalFortuneBonus += curioCapability.orElseGet(null).getFortuneBonus(identifier, player, stack, index);
-						}
-					}
-				}
-			}
+			totalFortuneBonus = CuriosApi.getCuriosHelper().getCuriosHandler(player).orElse(null).getFortuneBonus();
 		}
 
 		if (totalFortuneBonus <= 0)

--- a/src/main/java/top/theillusivec4/curios/common/objects/FortuneBonusModifier.java
+++ b/src/main/java/top/theillusivec4/curios/common/objects/FortuneBonusModifier.java
@@ -66,8 +66,6 @@ public class FortuneBonusModifier extends LootModifier {
 					if (!player.world.isRemote && !stack.isEmpty()) {
 						if (curioCapability.isPresent()) {
 							totalFortuneBonus += curioCapability.orElseGet(null).getFortuneBonus(identifier, player, stack, index);
-						} else {
-							totalFortuneBonus += EnchantmentHelper.getEnchantmentLevel(Enchantments.FORTUNE, stack);
 						}
 					}
 				}

--- a/src/main/java/top/theillusivec4/curios/common/triggers/EquipCurioTrigger.java
+++ b/src/main/java/top/theillusivec4/curios/common/triggers/EquipCurioTrigger.java
@@ -14,8 +14,10 @@ import javax.annotation.Nonnull;
 
 /**
  * This should be triggered whenever player successfully equips any item in their curios slot.
- * In theory, the item may not neccessarily be valid for slot or have ICurio capability attached
+ * In theory, the item may not necessarily be valid for slot or have ICurio capability attached
  * to it at all, but that is mostly unimportant under normal circumstances.
+ * 
+ * Current implementation allows to perform item and location tests in criteria.
  */
 
 public class EquipCurioTrigger extends AbstractCriterionTrigger<EquipCurioTrigger.Instance> {

--- a/src/main/java/top/theillusivec4/curios/common/triggers/EquipCurioTrigger.java
+++ b/src/main/java/top/theillusivec4/curios/common/triggers/EquipCurioTrigger.java
@@ -12,6 +12,12 @@ import top.theillusivec4.curios.Curios;
 
 import javax.annotation.Nonnull;
 
+/**
+ * This should be triggered whenever player successfully equips any item in their curios slot.
+ * In theory, the item may not neccessarily be valid for slot or have ICurio capability attached
+ * to it at all, but that is mostly unimportant under normal circumstances.
+ */
+
 public class EquipCurioTrigger extends AbstractCriterionTrigger<EquipCurioTrigger.Instance> {
 	public static final ResourceLocation ID = new ResourceLocation(Curios.MODID, "equip_curio");
 	public static final EquipCurioTrigger INSTANCE = new EquipCurioTrigger();

--- a/src/main/java/top/theillusivec4/curios/common/triggers/EquipCurioTrigger.java
+++ b/src/main/java/top/theillusivec4/curios/common/triggers/EquipCurioTrigger.java
@@ -1,0 +1,58 @@
+package top.theillusivec4.curios.common.triggers;
+
+import com.google.gson.JsonObject;
+
+import net.minecraft.advancements.criterion.*;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.loot.ConditionArrayParser;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.server.ServerWorld;
+import top.theillusivec4.curios.Curios;
+
+import javax.annotation.Nonnull;
+
+public class EquipCurioTrigger extends AbstractCriterionTrigger<EquipCurioTrigger.Instance> {
+	public static final ResourceLocation ID = new ResourceLocation(Curios.MODID, "equip_curio");
+	public static final EquipCurioTrigger INSTANCE = new EquipCurioTrigger();
+
+	private EquipCurioTrigger() {
+	}
+
+	@Nonnull
+	@Override
+	public ResourceLocation getId() {
+		return ID;
+	}
+
+	@Nonnull
+	@Override
+	public EquipCurioTrigger.Instance deserializeTrigger(@Nonnull JsonObject json, @Nonnull EntityPredicate.AndPredicate playerPred, ConditionArrayParser conditions) {
+		return new EquipCurioTrigger.Instance(playerPred, ItemPredicate.deserialize(json.get("item")), LocationPredicate.deserialize(json.get("location")));
+	}
+
+	public void trigger(ServerPlayerEntity player, ItemStack stack, ServerWorld world, double x, double y, double z) {
+		this.triggerListeners(player, instance -> instance.test(stack, world, x, y, z));
+	}
+
+	static class Instance extends CriterionInstance {
+		private final ItemPredicate item;
+		private final LocationPredicate location;
+
+		Instance(EntityPredicate.AndPredicate playerPred, ItemPredicate count, LocationPredicate indexPos) {
+			super(ID, playerPred);
+			this.item = count;
+			this.location = indexPos;
+		}
+
+		@Nonnull
+		@Override
+		public ResourceLocation getId() {
+			return ID;
+		}
+
+		boolean test(ItemStack stack, ServerWorld world, double x, double y, double z) {
+			return this.item.test(stack) && this.location.test(world, x, y, z);
+		}
+	}
+}

--- a/src/main/resources/assets/curios/lang/ru_ru.json
+++ b/src/main/resources/assets/curios/lang/ru_ru.json
@@ -1,6 +1,7 @@
 {
   "curios.name": "Curios",
   "curios.slot": "Слот",
+  "curios.cosmetic": "Украшение:",
   "commands.curios.set.success": "Количество слотов типа «%s» было изменено на %d для %s",
   "commands.curios.add.success": "%d слотов типа «%s» было добавлено для %s",
   "commands.curios.remove.success": "%d слотов типа «%s» было убрано у %s",
@@ -23,6 +24,7 @@
   "curios.identifier.body": "Тело",
   "curios.identifier.charm": "Амулет",
   "curios.identifier.hands": "Руки",
+  "curios.identifier.bracelet": "Браслет",
   "curios.modifiers.curio": "Если надето как аксессуар:",
   "curios.modifiers.necklace": "При ношении на шее:",
   "curios.modifiers.ring": "Если надето как кольцо:",
@@ -32,6 +34,8 @@
   "curios.modifiers.body": "При ношении на теле:",
   "curios.modifiers.charm": "Если надето как амулет:",
   "curios.modifiers.hands": "При ношении на руках:",
+  "curios.modifiers.bracelet": "Если надето как браслет:",
   "key.curios.category": "Curios",
-  "key.curios.open.desc": "Открыть/Закрыть инвентарь Curios"
+  "key.curios.open.desc": "Открыть/Закрыть инвентарь Curios",
+  "gui.curios.toggle": "Переключить видимость"
 }

--- a/src/main/resources/data/curios/loot_modifiers/fortune_bonus.json
+++ b/src/main/resources/data/curios/loot_modifiers/fortune_bonus.json
@@ -1,0 +1,4 @@
+{
+  "conditions": [],
+  "function": "curios:fortune_bonus"
+}

--- a/src/main/resources/data/forge/loot_modifiers/global_loot_modifiers.json
+++ b/src/main/resources/data/forge/loot_modifiers/global_loot_modifiers.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "entries": [
+    "curios:fortune_bonus"
+  ]
+}


### PR DESCRIPTION
So, list of changes:

### Fixes: 
* A bug (I believe) where recipe book, if toggled visible while in survival, is still visible in Curios inventory when after switching to creative mode. The recipe book button is removed so it's not even possible to toggle it off without switching back to survival mode. Current fix does simply disable visibility of recipe book when opening Curios inventory in creative menu, which may not be perfect, but I couldn't come up with something better that would not have any potential conflicts with other mod's inventories that iherit same recipe book. Perhaps I am just dumb and there's much simpler solution. Current one is better than it used to be anyways.

### Features:
* `ICurio#showAttributesTooltip` call that kindly asks each curio whether or not tooltip listing their attributes when worn should be added, for each identifier. Sometimes mod creators might want to outline those attributes as part of their own stylized tooltip, similar to how I often do. I noticed `"HideFlags"` nbt check in `ItemTooltipEvent` listener which in theory may allow to achieve this, but it seems to be an inherited vanilla behaviour that isn't very obvious and I guess affects more than just Curios attribute tooltips.

* Added `curios:equip_curio` criterion trigger, which is fired in same places where `ICurio#onEquip` calls are dispatched. Current implementation allows to perform item and/or location tests if neccessary. Might prove useful for some custom advancements thingies.

* Added compatibility with Fortune and Looting enchantments. Default implementation considers enchantment levels of these enchantments applied to each curio `ItemStack`, if there are any, then applying total Fortune bonus through special `GlobalLootModifierSerializer` and Looting through `LootingLevelEvent`, respectively. Of course wearables cannot legitimately receive those enchantments by default, but mod creators can make it possible for their individual trinkets I suppose. Furthermore, default implementations reside in `ICurio`, as a way to alter or completely override amount of provided enchantment levels for both Looting and Fortune bonuses.
This functionality can surely be achieved by each mod on their own, but I assume many mod creators may want to add curios that simply increase Fortune and/or Looting traits when worn, so why not spare us a burden of having to reinvent and reimplement this wheel.

### Localization:
* Updated Russian localization.

If you aim for parity between Forge and Fabric versions, it might be fair to somehow implement this stuff on Fabric port either, but I unfortunately can't help with that as so far I still have no idea what Fabric is even about.