### PR TITLE
More sensitive ICurio calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ build
 # other
 eclipse
 run
+logs
+/Users/

--- a/src/main/java/top/theillusivec4/curios/api/type/capability/ICurio.java
+++ b/src/main/java/top/theillusivec4/curios/api/type/capability/ICurio.java
@@ -37,6 +37,7 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.ai.attributes.Attribute;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.particles.ItemParticleData;
 import net.minecraft.particles.ParticleTypes;
@@ -55,34 +56,31 @@ public interface ICurio {
    */
   static void playBreakAnimation(ItemStack stack, LivingEntity livingEntity) {
 
-    if (!stack.isEmpty()) {
+	if (!stack.isEmpty()) {
 
-      if (!livingEntity.isSilent()) {
-        livingEntity.world
-            .playSound(livingEntity.getPosX(), livingEntity.getPosY(), livingEntity.getPosZ(),
-                SoundEvents.ENTITY_ITEM_BREAK, livingEntity.getSoundCategory(), 0.8F,
-                0.8F + livingEntity.world.rand.nextFloat() * 0.4F, false);
-      }
+	  if (!livingEntity.isSilent()) {
+		livingEntity.world.playSound(livingEntity.getPosX(), livingEntity.getPosY(), livingEntity.getPosZ(),
+			SoundEvents.ENTITY_ITEM_BREAK, livingEntity.getSoundCategory(), 0.8F,
+			0.8F + livingEntity.world.rand.nextFloat() * 0.4F, false);
+	  }
 
-      for (int i = 0; i < 5; ++i) {
-        Vector3d vec3d = new Vector3d((livingEntity.getRNG().nextFloat() - 0.5D) * 0.1D,
-            Math.random() * 0.1D + 0.1D, 0.0D);
-        vec3d = vec3d.rotatePitch(-livingEntity.rotationPitch * ((float) Math.PI / 180F));
-        vec3d = vec3d.rotateYaw(-livingEntity.rotationYaw * ((float) Math.PI / 180F));
-        double d0 = (-livingEntity.getRNG().nextFloat()) * 0.6D - 0.3D;
+	  for (int i = 0; i < 5; ++i) {
+		Vector3d vec3d = new Vector3d((livingEntity.getRNG().nextFloat() - 0.5D) * 0.1D, Math.random() * 0.1D + 0.1D,
+			0.0D);
+		vec3d = vec3d.rotatePitch(-livingEntity.rotationPitch * ((float) Math.PI / 180F));
+		vec3d = vec3d.rotateYaw(-livingEntity.rotationYaw * ((float) Math.PI / 180F));
+		double d0 = (-livingEntity.getRNG().nextFloat()) * 0.6D - 0.3D;
 
-        Vector3d vec3d1 = new Vector3d((livingEntity.getRNG().nextFloat() - 0.5D) * 0.3D,
-            d0, 0.6D);
-        vec3d1 = vec3d1.rotatePitch(-livingEntity.rotationPitch * ((float) Math.PI / 180F));
-        vec3d1 = vec3d1.rotateYaw(-livingEntity.rotationYaw * ((float) Math.PI / 180F));
-        vec3d1 = vec3d1.add(livingEntity.getPosX(),
-            livingEntity.getPosY() + livingEntity.getEyeHeight(), livingEntity.getPosZ());
+		Vector3d vec3d1 = new Vector3d((livingEntity.getRNG().nextFloat() - 0.5D) * 0.3D, d0, 0.6D);
+		vec3d1 = vec3d1.rotatePitch(-livingEntity.rotationPitch * ((float) Math.PI / 180F));
+		vec3d1 = vec3d1.rotateYaw(-livingEntity.rotationYaw * ((float) Math.PI / 180F));
+		vec3d1 = vec3d1.add(livingEntity.getPosX(), livingEntity.getPosY() + livingEntity.getEyeHeight(),
+			livingEntity.getPosZ());
 
-        livingEntity.world
-            .addParticle(new ItemParticleData(ParticleTypes.ITEM, stack), vec3d1.x, vec3d1.y,
-                vec3d1.z, vec3d.x, vec3d.y + 0.05D, vec3d.z);
-      }
-    }
+		livingEntity.world.addParticle(new ItemParticleData(ParticleTypes.ITEM, stack), vec3d1.x, vec3d1.y, vec3d1.z,
+			vec3d.x, vec3d.y + 0.05D, vec3d.z);
+	  }
+	}
   }
 
   /**
@@ -91,8 +89,36 @@ public interface ICurio {
    * @param identifier   The {@link ISlotType} identifier of the ItemStack's slot
    * @param index        The index of the slot
    * @param livingEntity The wearer of the ItemStack
+   * @deprecated Use ItemStack-sensitive version
    */
+  @Deprecated
   default void curioTick(String identifier, int index, LivingEntity livingEntity) {
+
+  }
+
+  /**
+   * Called every tick on both client and server while the ItemStack is equipped.
+   *
+   * @param identifier   The {@link ISlotType} identifier of the ItemStack's slot
+   * @param index        The index of the slot
+   * @param livingEntity The wearer of the ItemStack
+   * @param stack        The ItemStack in question
+   */
+  default void curioTick(String identifier, int index, LivingEntity livingEntity, ItemStack stack) {
+	this.curioTick(identifier, index, livingEntity);
+	return;
+  }
+
+  /**
+   * Called every tick only on the client while the ItemStack is equipped.
+   *
+   * @param identifier   The {@link ISlotType} identifier of the ItemStack's slot
+   * @param index        The index of the slot
+   * @param livingEntity The wearer of the ItemStack
+   * @deprecated Use ItemStack-sensitive version
+   */
+  @Deprecated
+  default void curioAnimate(String identifier, int index, LivingEntity livingEntity) {
 
   }
 
@@ -102,140 +128,256 @@ public interface ICurio {
    * @param identifier   The {@link ISlotType} identifier of the ItemStack's slot
    * @param index        The index of the slot
    * @param livingEntity The wearer of the ItemStack
+   * @param stack        The ItemStack in question
    */
-  default void curioAnimate(String identifier, int index, LivingEntity livingEntity) {
+  default void curioAnimate(String identifier, int index, LivingEntity livingEntity, ItemStack stack) {
+	this.curioAnimate(identifier, index, livingEntity);
+	return;
+  }
+
+  /**
+   * Called when the ItemStack is equipped into a slot.
+   *
+   * @param identifier   The {@link ISlotType} identifier of the slot being
+   *                     equipped into
+   * @param index        The index of the slot
+   * @param livingEntity The wearer of the ItemStack
+   * @deprecated Use ItemStack-sensitive version
+   */
+  @Deprecated
+  default void onEquip(String identifier, int index, LivingEntity livingEntity) {
 
   }
 
   /**
    * Called when the ItemStack is equipped into a slot.
    *
-   * @param identifier   The {@link ISlotType} identifier of the slot being equipped into
+   * @param identifier   The {@link ISlotType} identifier of the slot being
+   *                     equipped into
    * @param index        The index of the slot
    * @param livingEntity The wearer of the ItemStack
+   * @param stack        The ItemStack in question
    */
-  default void onEquip(String identifier, int index, LivingEntity livingEntity) {
+  default void onEquip(String identifier, int index, LivingEntity livingEntity, ItemStack stack) {
+	this.onEquip(identifier, index, livingEntity);
+	return;
+  }
+
+  /**
+   * Called when the ItemStack is unequipped from a slot.
+   *
+   * @param identifier   The {@link ISlotType} identifier of the slot being
+   *                     unequipped from
+   * @param index        The index of the slot
+   * @param livingEntity The wearer of the ItemStack
+   * @deprecated Use ItemStack-sensitive version
+   */
+  @Deprecated
+  default void onUnequip(String identifier, int index, LivingEntity livingEntity) {
 
   }
 
   /**
    * Called when the ItemStack is unequipped from a slot.
    *
-   * @param identifier   The {@link ISlotType} identifier of the slot being unequipped from
+   * @param identifier   The {@link ISlotType} identifier of the slot being
+   *                     unequipped from
    * @param index        The index of the slot
    * @param livingEntity The wearer of the ItemStack
+   * @param stack        The ItemStack in question
    */
-  default void onUnequip(String identifier, int index, LivingEntity livingEntity) {
-
+  default void onUnequip(String identifier, int index, LivingEntity livingEntity, ItemStack stack) {
+	this.onUnequip(identifier, index, livingEntity);
+	return;
   }
 
   /**
    * Determines if the ItemStack can be equipped into a slot.
    *
-   * @param identifier   The {@link ISlotType} identifier of the slot being equipped into
+   * @param identifier   The {@link ISlotType} identifier of the slot being
+   *                     equipped into
    * @param livingEntity The wearer of the ItemStack
    * @return True if the ItemStack can be equipped/put in, false if not
+   * @deprecated Use ItemStack-sensitive version
    */
+  @Deprecated
   default boolean canEquip(String identifier, LivingEntity livingEntity) {
-    return true;
+	return true;
+  }
+
+  /**
+   * Determines if the ItemStack can be equipped into a slot.
+   *
+   * @param identifier   The {@link ISlotType} identifier of the slot being
+   *                     equipped into
+   * @param livingEntity The wearer of the ItemStack
+   * @param stack The ItemStack in question
+   * @return True if the ItemStack can be equipped/put in, false if not
+   */
+  default boolean canEquip(String identifier, LivingEntity livingEntity, ItemStack stack) {
+	return this.canEquip(identifier, livingEntity);
   }
 
   /**
    * Determines if the ItemStack can be unequipped from a slot.
    *
-   * @param identifier   The {@link ISlotType} identifier of the slot being unequipped from
+   * @param identifier   The {@link ISlotType} identifier of the slot being
+   *                     unequipped from
    * @param livingEntity The wearer of the ItemStack
    * @return True if the ItemStack can be unequipped/taken out, false if not
+   * @deprecated Use index- and ItemStack-sensitive version
    */
+  @Deprecated
   default boolean canUnequip(String identifier, LivingEntity livingEntity) {
-    return true;
+	return true;
   }
 
   /**
-   * Retrieves a list of tooltips when displaying curio tag information. By default, this will be a
-   * list of each tag identifier, translated and in gold text, associated with the curio.
-   * <br>
-   * If overriding, make sure the user has some indication which tags are associated with the
-   * curio.
+   * Determines if the ItemStack can be unequipped from a slot.
+   *
+   * @param identifier   The {@link ISlotType} identifier of the slot being
+   *                     unequipped from
+   * @param livingEntity The wearer of the ItemStack
+   * @param stack The ItemStack in question
+   * @param index Index of slot where ItemStack resides
+   * @return True if the ItemStack can be unequipped/taken out, false if not
+   */
+  default boolean canUnequip(String identifier, LivingEntity livingEntity, ItemStack stack, int index) {
+	return this.canUnequip(identifier, livingEntity);
+  }
+
+  /**
+   * Retrieves a list of tooltips when displaying curio tag information. By
+   * default, this will be a list of each tag identifier, translated and in gold
+   * text, associated with the curio. <br>
+   * If overriding, make sure the user has some indication which tags are
+   * associated with the curio.
    *
    * @param tagTooltips A list of {@link ITextComponent} with every curio tag
    * @return A list of ITextComponent to display as curio tag information
    */
   default List<ITextComponent> getTagsTooltip(List<ITextComponent> tagTooltips) {
-    return tagTooltips;
+	return tagTooltips;
   }
 
   /**
-   * A map of AttributeModifier associated with the ItemStack and the {@link ISlotType} identifier.
+   * A map of AttributeModifier associated with the ItemStack and the
+   * {@link ISlotType} identifier.
    *
    * @param identifier The CurioType identifier for the context
    * @return A map of attribute modifiers to apply
+   * @deprecated Use ItemStack-sensitive version
    */
+  @Deprecated
   default Multimap<Attribute, AttributeModifier> getAttributeModifiers(String identifier) {
-    return HashMultimap.create();
+	return HashMultimap.create();
   }
 
   /**
-   * Plays a sound server-side when a curio is equipped from right-clicking the ItemStack in hand.
-   * This can be overridden to play nothing, but it is advised to always play something as an
-   * auditory feedback for players.
+   * A map of AttributeModifier associated with the ItemStack and the
+   * {@link ISlotType} identifier.
+   *
+   * @param identifier The CurioType identifier for the context
+   * @param stack The ItemStack in question
+   * @return A map of attribute modifiers to apply
+   */
+  default Multimap<Attribute, AttributeModifier> getAttributeModifiers(String identifier, ItemStack stack) {
+	return this.getAttributeModifiers(identifier);
+  }
+
+  /**
+   * Plays a sound server-side when a curio is equipped from right-clicking the
+   * ItemStack in hand. This can be overridden to play nothing, but it is advised
+   * to always play something as an auditory feedback for players.
    *
    * @param livingEntity The wearer of the ItemStack
+   * @deprecated Use identifier- and ItemStack-sensitive version
    */
+  @Deprecated
   default void playRightClickEquipSound(LivingEntity livingEntity) {
-    livingEntity.world.playSound(null, new BlockPos(livingEntity.getPositionVec()),
-        SoundEvents.ITEM_ARMOR_EQUIP_GENERIC, SoundCategory.NEUTRAL, 1.0f, 1.0f);
+	livingEntity.world.playSound(null, new BlockPos(livingEntity.getPositionVec()),
+		SoundEvents.ITEM_ARMOR_EQUIP_GENERIC, SoundCategory.NEUTRAL, 1.0f, 1.0f);
   }
 
   /**
-   * Determines if the ItemStack can be automatically equipped into the first available slot when
-   * right-clicked.
+   * Plays a sound server-side when a curio is equipped from right-clicking the
+   * ItemStack in hand. This can be overridden to play nothing, but it is advised
+   * to always play something as an auditory feedback for players.
+   *
+   * @param livingEntity The wearer of the ItemStack
+   * @param identifier Identifier of slot into which stack is equipped
+   * @param stack The ItemStack in question
+   */
+  default void playRightClickEquipSound(String identifier, LivingEntity livingEntity, ItemStack stack) {
+	this.playRightClickEquipSound(livingEntity);
+  }
+
+  /**
+   * Determines if the ItemStack can be automatically equipped into the first
+   * available slot when right-clicked.
    *
    * @return True to enable right-clicking auto-equip, false to disable
+   * @deprecated Use version with ItemStack and LivingEntity arguments
    */
+  @Deprecated
   default boolean canRightClickEquip() {
-    return false;
+	return false;
   }
 
   /**
-   * Called when rendering break animations and sounds client-side when a worn curio item is
-   * broken.
+   * Determines if the ItemStack can be automatically equipped into the first
+   * available slot when right-clicked.
+   *
+   * @param livingEntity The wearer of the ItemStack
+   * @param stack The ItemStack in question
+   * @return True to enable right-clicking auto-equip, false to disable
+   */
+  default boolean canRightClickEquip(LivingEntity livingEntity, ItemStack stack) {
+	return this.canRightClickEquip();
+  }
+
+  /**
+   * Called when rendering break animations and sounds client-side when a worn
+   * curio item is broken.
    *
    * @param stack        The ItemStack that was broken
    * @param livingEntity The entity that broke the curio
    */
   default void curioBreak(ItemStack stack, LivingEntity livingEntity) {
-    playBreakAnimation(stack, livingEntity);
+	playBreakAnimation(stack, livingEntity);
   }
 
   /**
-   * Compares the current ItemStack and the previous ItemStack in the slot to detect any changes and
-   * returns true if the change should be synced to all tracking clients. Note that this check
-   * occurs every tick so implementations need to code their own timers for other intervals.
+   * Compares the current ItemStack and the previous ItemStack in the slot to
+   * detect any changes and returns true if the change should be synced to all
+   * tracking clients. Note that this check occurs every tick so implementations
+   * need to code their own timers for other intervals.
    *
    * @param identifier   The identifier of the {@link ISlotType} of the slot
    * @param index        The index of the slot
    * @param livingEntity The LivingEntity that is wearing the ItemStack
-   * @return True to sync the ItemStack change to all tracking clients, false to do nothing
+   * @return True to sync the ItemStack change to all tracking clients, false to
+   *         do nothing
    */
   default boolean canSync(String identifier, int index, LivingEntity livingEntity) {
-    return false;
+	return false;
   }
 
   /**
-   * Gets a tag that is used to sync extra curio data from the server to the client. Only used when
-   * {@link ICurio#canSync(String, int, LivingEntity)} returns true.
+   * Gets a tag that is used to sync extra curio data from the server to the
+   * client. Only used when {@link ICurio#canSync(String, int, LivingEntity)}
+   * returns true.
    *
    * @return Data to be sent to the client
    */
   @Nonnull
   default CompoundNBT writeSyncData() {
-    return new CompoundNBT();
+	return new CompoundNBT();
   }
 
   /**
-   * Used client-side to read data tags created by {@link ICurio#writeSyncData()} received from the
-   * server.
+   * Used client-side to read data tags created by {@link ICurio#writeSyncData()}
+   * received from the server.
    *
    * @param compound Data received from the server
    */
@@ -244,26 +386,60 @@ public interface ICurio {
   }
 
   /**
-   * Determines if the ItemStack should drop on death and persist through respawn. This will persist
-   * the ItemStack in the curio slot to the respawned player if applicable.
+   * Determines if the ItemStack should drop on death and persist through respawn.
+   * This will persist the ItemStack in the curio slot to the respawned player if
+   * applicable.
    *
    * @param livingEntity The entity that died
    * @return {@link DropRule}
+   * @deprecated Use identifier- and ItemStack-sensitive version
    */
+  @Deprecated
   @Nonnull
   default DropRule getDropRule(LivingEntity livingEntity) {
-    return DropRule.DEFAULT;
+	return DropRule.DEFAULT;
   }
 
   /**
-   * Determines whether or not Curios will automatically add tooltip listing attribute modifiers
-   * that are returned by {@link ICurio#getAttributeModifiers(String)}.
+   * Determines if the ItemStack should drop on death and persist through respawn.
+   * This will persist the ItemStack in the curio slot to the respawned player if
+   * applicable.
    *
-   * @param identifier   The identifier of the {@link ISlotType} of the slot
+   * @param livingEntity The entity that died
+   * @param identifier Identifier of slot into which stack is equipped
+   * @param stack The ItemStack in question
+   * @return {@link DropRule}
+   */
+  @Nonnull
+  default DropRule getDropRule(String identifier, LivingEntity livingEntity, ItemStack stack) {
+	return this.getDropRule(livingEntity);
+  }
+
+  /**
+   * Determines whether or not Curios will automatically add tooltip listing
+   * attribute modifiers that are returned by
+   * {@link ICurio#getAttributeModifiers(String)}.
+   *
+   * @param identifier The identifier of the {@link ISlotType} of the slot
+   * @return True to show attributes tooltip, false to disable
+   * @deprecated Use ItemStack-sensitive version
+   */
+  @Deprecated
+  default boolean showAttributesTooltip(String identifier) {
+	return true;
+  }
+
+  /**
+   * Determines whether or not Curios will automatically add tooltip listing
+   * attribute modifiers that are returned by
+   * {@link ICurio#getAttributeModifiers(String)}.
+   *
+   * @param identifier The identifier of the {@link ISlotType} of the slot
+   * @param stack The ItemStack in question
    * @return True to show attributes tooltip, false to disable
    */
-  default boolean showAttributesTooltip(String identifier) {
-    return true;
+  default boolean showAttributesTooltip(String identifier, ItemStack stack) {
+	return this.showAttributesTooltip(identifier);
   }
 
   /**
@@ -271,13 +447,13 @@ public interface ICurio {
    * Default implementation returns level of Fortune enchantment on ItemStack.
    *
    * @param identifier   The identifier of the {@link ISlotType} of the slot
-   * @param curio	ItemStack that is checked
+   * @param curio        ItemStack that is checked
    * @param index        The index of the slot
    * @param livingEntity The LivingEntity that is wearing the ItemStack
    * @return Amount of additional Fortune levels that will be applied when mining
    */
   default int getFortuneBonus(String identifier, LivingEntity livingEntity, ItemStack curio, int index) {
-    return EnchantmentHelper.getEnchantmentLevel(Enchantments.FORTUNE, curio);
+	return EnchantmentHelper.getEnchantmentLevel(Enchantments.FORTUNE, curio);
   }
 
   /**
@@ -285,13 +461,14 @@ public interface ICurio {
    * Default implementation returns level of Looting enchantment on ItemStack.
    *
    * @param identifier   The identifier of the {@link ISlotType} of the slot
-   * @param curio	ItemStack that is checked
+   * @param curio        ItemStack that is checked
    * @param index        The index of the slot
    * @param livingEntity The LivingEntity that is wearing the ItemStack
-   * @return Amount of additional Looting levels that will be applied in LootingLevelEvent
+   * @return Amount of additional Looting levels that will be applied in
+   *         LootingLevelEvent
    */
   default int getLootingBonus(String identifier, LivingEntity livingEntity, ItemStack curio, int index) {
-    return EnchantmentHelper.getEnchantmentLevel(Enchantments.LOOTING, curio);
+	return EnchantmentHelper.getEnchantmentLevel(Enchantments.LOOTING, curio);
   }
 
   /**
@@ -301,39 +478,74 @@ public interface ICurio {
    * @param index        The index of the slot
    * @param livingEntity The LivingEntity that is wearing the ItemStack
    * @return True if the ItemStack has rendering, false if it does not
+   * @deprecated Use ItemStack-sensitive version
    */
+  @Deprecated
   default boolean canRender(String identifier, int index, LivingEntity livingEntity) {
-    return false;
+	return false;
   }
 
   /**
-   * Performs rendering of the ItemStack if {@link ICurio#canRender(String, int, LivingEntity)}
-   * returns true. Note that vertical sneaking translations are automatically applied before this
+   * Determines if the ItemStack has rendering.
+   *
+   * @param identifier   The identifier of the {@link ISlotType} of the slot
+   * @param index        The index of the slot
+   * @param livingEntity The LivingEntity that is wearing the ItemStack
+   * @param stack The ItemStack in question
+   * @return True if the ItemStack has rendering, false if it does not
+   */
+  default boolean canRender(String identifier, int index, LivingEntity livingEntity, ItemStack stack) {
+	return this.canRender(identifier, index, livingEntity);
+  }
+
+  /**
+   * Performs rendering of the ItemStack if
+   * {@link ICurio#canRender(String, int, LivingEntity)} returns true. Note that
+   * vertical sneaking translations are automatically applied before this
    * rendering method is called.
    *
    * @param identifier   The identifier of the {@link ISlotType} of the slot
    * @param livingEntity The LivingEntity that is wearing the ItemStack
+   * @deprecated Use ItemStack-sensitive version
    */
-  default void render(String identifier, int index, MatrixStack matrixStack,
-      IRenderTypeBuffer renderTypeBuffer, int light, LivingEntity livingEntity, float limbSwing,
-      float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw,
-      float headPitch) {
+  @Deprecated
+  default void render(String identifier, int index, MatrixStack matrixStack, IRenderTypeBuffer renderTypeBuffer,
+	  int light, LivingEntity livingEntity, float limbSwing, float limbSwingAmount, float partialTicks,
+	  float ageInTicks, float netHeadYaw, float headPitch) {
 
   }
 
   /**
-   * Used by {@link ICurio#getDropRule(LivingEntity)} to determine drop on death behavior.
-   * <br>
-   * DEFAULT - normal vanilla behavior with drops dictated by the Keep Inventory game rule
-   * <br>
-   * ALWAYS_DROP - always drop regardless of game rules
-   * <br>
-   * ALWAYS_KEEP - always keep regardless of game rules
-   * <br>
+   * Performs rendering of the ItemStack if
+   * {@link ICurio#canRender(String, int, LivingEntity)} returns true. Note that
+   * vertical sneaking translations are automatically applied before this
+   * rendering method is called.
+   *
+   * @param identifier   The identifier of the {@link ISlotType} of the slot
+   * @param livingEntity The LivingEntity that is wearing the ItemStack
+   * @param stack The ItemStack in question
+   */
+  default void render(String identifier, int index, MatrixStack matrixStack, IRenderTypeBuffer renderTypeBuffer,
+	  int light, LivingEntity livingEntity, float limbSwing, float limbSwingAmount, float partialTicks,
+	  float ageInTicks, float netHeadYaw, float headPitch, ItemStack stack) {
+
+	this.render(identifier, index, matrixStack, renderTypeBuffer, light, livingEntity, limbSwing, limbSwingAmount,
+		partialTicks, ageInTicks, netHeadYaw, headPitch);
+
+	return;
+  }
+
+  /**
+   * Used by {@link ICurio#getDropRule(LivingEntity)} to determine drop on death
+   * behavior. <br>
+   * DEFAULT - normal vanilla behavior with drops dictated by the Keep Inventory
+   * game rule <br>
+   * ALWAYS_DROP - always drop regardless of game rules <br>
+   * ALWAYS_KEEP - always keep regardless of game rules <br>
    * DESTROY - destroy the item upon death
    */
   enum DropRule {
-    DEFAULT, ALWAYS_DROP, ALWAYS_KEEP, DESTROY
+	DEFAULT, ALWAYS_DROP, ALWAYS_KEEP, DESTROY
   }
 
   /**
@@ -341,89 +553,89 @@ public interface ICurio {
    */
   final class RenderHelper {
 
-    /**
-     * Translates the rendering for the curio if the entity is sneaking.
-     *
-     * @param livingEntity The wearer of the curio
-     */
-    public static void translateIfSneaking(final MatrixStack matrixStack,
-        final LivingEntity livingEntity) {
+	/**
+	 * Translates the rendering for the curio if the entity is sneaking.
+	 *
+	 * @param livingEntity The wearer of the curio
+	 */
+	public static void translateIfSneaking(final MatrixStack matrixStack, final LivingEntity livingEntity) {
 
-      if (livingEntity.isCrouching()) {
-        matrixStack.translate(0.0f, 0.2f, 0.0f);
-      }
-    }
+	  if (livingEntity.isCrouching()) {
+		matrixStack.translate(0.0f, 0.2f, 0.0f);
+	  }
+	}
 
-    /**
-     * Rotates the rendering for the curio if the entity is sneaking. The rotation angle is based on
-     * the body of a player model when sneaking, so this is typically used for items being rendered
-     * on the body.
-     *
-     * @param livingEntity The wearer of the curio
-     */
-    public static void rotateIfSneaking(final MatrixStack matrixStack,
-        final LivingEntity livingEntity) {
+	/**
+	 * Rotates the rendering for the curio if the entity is sneaking. The rotation
+	 * angle is based on the body of a player model when sneaking, so this is
+	 * typically used for items being rendered on the body.
+	 *
+	 * @param livingEntity The wearer of the curio
+	 */
+	public static void rotateIfSneaking(final MatrixStack matrixStack, final LivingEntity livingEntity) {
 
-      if (livingEntity.isCrouching()) {
-        matrixStack.rotate(Vector3f.XP.rotationDegrees(90.0F / (float) Math.PI));
-      }
-    }
+	  if (livingEntity.isCrouching()) {
+		matrixStack.rotate(Vector3f.XP.rotationDegrees(90.0F / (float) Math.PI));
+	  }
+	}
 
-    /**
-     * Rotates the rendering for the model renderers based on the entity's head movement. This will
-     * align the model renderers with the movements and rotations of the head. This will do nothing
-     * if the entity render object does not implement {@link LivingRenderer} or if the model does
-     * not have a head (does not implement {@link BipedModel}).
-     *
-     * @param livingEntity The wearer of the curio
-     * @param renderers    The list of model renderers to align to the head movement
-     */
-    public static void followHeadRotations(final LivingEntity livingEntity,
-        ModelRenderer... renderers) {
+	/**
+	 * Rotates the rendering for the model renderers based on the entity's head
+	 * movement. This will align the model renderers with the movements and
+	 * rotations of the head. This will do nothing if the entity render object does
+	 * not implement {@link LivingRenderer} or if the model does not have a head
+	 * (does not implement {@link BipedModel}).
+	 *
+	 * @param livingEntity The wearer of the curio
+	 * @param renderers    The list of model renderers to align to the head movement
+	 */
+	public static void followHeadRotations(final LivingEntity livingEntity, ModelRenderer... renderers) {
 
-      EntityRenderer<? super LivingEntity> render = Minecraft.getInstance().getRenderManager()
-          .getRenderer(livingEntity);
+	  EntityRenderer<? super LivingEntity> render = Minecraft.getInstance().getRenderManager()
+		  .getRenderer(livingEntity);
 
-      if (render instanceof LivingRenderer) {
-        @SuppressWarnings("unchecked") LivingRenderer<LivingEntity, EntityModel<LivingEntity>> livingRenderer = (LivingRenderer<LivingEntity, EntityModel<LivingEntity>>) render;
-        EntityModel<LivingEntity> model = livingRenderer.getEntityModel();
+	  if (render instanceof LivingRenderer) {
+		@SuppressWarnings("unchecked")
+		LivingRenderer<LivingEntity, EntityModel<LivingEntity>> livingRenderer = (LivingRenderer<LivingEntity, EntityModel<LivingEntity>>) render;
+		EntityModel<LivingEntity> model = livingRenderer.getEntityModel();
 
-        if (model instanceof BipedModel) {
+		if (model instanceof BipedModel) {
 
-          for (ModelRenderer renderer : renderers) {
-            renderer.copyModelAngles(((BipedModel<LivingEntity>) model).bipedHead);
-          }
-        }
-      }
-    }
+		  for (ModelRenderer renderer : renderers) {
+			renderer.copyModelAngles(((BipedModel<LivingEntity>) model).bipedHead);
+		  }
+		}
+	  }
+	}
 
-    /**
-     * Rotates the rendering for the models based on the entity's poses and movements. This will do
-     * nothing if the entity render object does not implement {@link LivingRenderer} or if the model
-     * does not implement {@link BipedModel}).
-     *
-     * @param livingEntity The wearer of the curio
-     * @param models       The list of models to align to the body movement
-     */
-    @SafeVarargs
-    public static void followBodyRotations(final LivingEntity livingEntity,
-        final BipedModel<LivingEntity>... models) {
+	/**
+	 * Rotates the rendering for the models based on the entity's poses and
+	 * movements. This will do nothing if the entity render object does not
+	 * implement {@link LivingRenderer} or if the model does not implement
+	 * {@link BipedModel}).
+	 *
+	 * @param livingEntity The wearer of the curio
+	 * @param models       The list of models to align to the body movement
+	 */
+	@SafeVarargs
+	public static void followBodyRotations(final LivingEntity livingEntity, final BipedModel<LivingEntity>... models) {
 
-      EntityRenderer<? super LivingEntity> render = Minecraft.getInstance().getRenderManager()
-          .getRenderer(livingEntity);
+	  EntityRenderer<? super LivingEntity> render = Minecraft.getInstance().getRenderManager()
+		  .getRenderer(livingEntity);
 
-      if (render instanceof LivingRenderer) {
-        @SuppressWarnings("unchecked") LivingRenderer<LivingEntity, EntityModel<LivingEntity>> livingRenderer = (LivingRenderer<LivingEntity, EntityModel<LivingEntity>>) render;
-        EntityModel<LivingEntity> entityModel = livingRenderer.getEntityModel();
+	  if (render instanceof LivingRenderer) {
+		@SuppressWarnings("unchecked")
+		LivingRenderer<LivingEntity, EntityModel<LivingEntity>> livingRenderer = (LivingRenderer<LivingEntity, EntityModel<LivingEntity>>) render;
+		EntityModel<LivingEntity> entityModel = livingRenderer.getEntityModel();
 
-        if (entityModel instanceof BipedModel) {
+		if (entityModel instanceof BipedModel) {
 
-          for (BipedModel<LivingEntity> model : models) {
-            BipedModel<LivingEntity> bipedModel = (BipedModel<LivingEntity>) entityModel;
-            bipedModel.setModelAttributes(model);
-          }
-        }
-      }
-    }
+		  for (BipedModel<LivingEntity> model : models) {
+			BipedModel<LivingEntity> bipedModel = (BipedModel<LivingEntity>) entityModel;
+			bipedModel.setModelAttributes(model);
+		  }
+		}
+	  }
+	}
   }
 }

--- a/src/main/java/top/theillusivec4/curios/client/ClientEventHandler.java
+++ b/src/main/java/top/theillusivec4/curios/client/ClientEventHandler.java
@@ -55,146 +55,145 @@ import top.theillusivec4.curios.common.network.client.CPacketOpenCurios;
 public class ClientEventHandler {
 
   private static final UUID ATTACK_DAMAGE_MODIFIER = UUID
-      .fromString("CB3F55D3-645C-4F38-A497-9C13A33DB5CF");
+	  .fromString("CB3F55D3-645C-4F38-A497-9C13A33DB5CF");
   private static final UUID ATTACK_SPEED_MODIFIER = UUID
-      .fromString("FA233E1C-4180-4865-B01B-BCCE9785ACA3");
+	  .fromString("FA233E1C-4180-4865-B01B-BCCE9785ACA3");
 
   @SubscribeEvent
   public void onKeyInput(TickEvent.ClientTickEvent evt) {
 
-    if (evt.phase != TickEvent.Phase.END) {
-      return;
-    }
+	if (evt.phase != TickEvent.Phase.END)
+	  return;
 
-    Minecraft mc = Minecraft.getInstance();
+	Minecraft mc = Minecraft.getInstance();
 
-    if (KeyRegistry.openCurios.isPressed() && mc.isGameFocused()) {
-      NetworkHandler.INSTANCE.send(PacketDistributor.SERVER.noArg(), new CPacketOpenCurios());
-    }
+	if (KeyRegistry.openCurios.isPressed() && mc.isGameFocused()) {
+	  NetworkHandler.INSTANCE.send(PacketDistributor.SERVER.noArg(), new CPacketOpenCurios());
+	}
   }
 
   @SubscribeEvent
   public void onTooltip(ItemTooltipEvent evt) {
 
-    ItemStack stack = evt.getItemStack();
+	ItemStack stack = evt.getItemStack();
 
-    if (!stack.isEmpty()) {
-      List<ITextComponent> tooltip = evt.getToolTip();
-      CompoundNBT tag = stack.getTag();
-      int i = 0;
+	if (!stack.isEmpty()) {
+	  List<ITextComponent> tooltip = evt.getToolTip();
+	  CompoundNBT tag = stack.getTag();
+	  int i = 0;
 
-      if (tag != null && tag.contains("HideFlags", 99)) {
-        i = tag.getInt("HideFlags");
-      }
+	  if (tag != null && tag.contains("HideFlags", 99)) {
+		i = tag.getInt("HideFlags");
+	  }
 
-      Set<String> curioTags = CuriosApi.getCuriosHelper().getCurioTags(stack.getItem());
-      List<String> slots = new ArrayList<>(curioTags);
+	  Set<String> curioTags = CuriosApi.getCuriosHelper().getCurioTags(stack.getItem());
+	  List<String> slots = new ArrayList<>(curioTags);
 
-      if (!slots.isEmpty()) {
-        List<ITextComponent> tagTooltips = new ArrayList<>();
-        IFormattableTextComponent slotsTooltip = new TranslationTextComponent("curios.slot")
-            .appendString(": ").mergeStyle(TextFormatting.GOLD);
+	  if (!slots.isEmpty()) {
+		List<ITextComponent> tagTooltips = new ArrayList<>();
+		IFormattableTextComponent slotsTooltip = new TranslationTextComponent("curios.slot")
+			.appendString(": ").mergeStyle(TextFormatting.GOLD);
 
-        for (int j = 0; j < slots.size(); j++) {
-          String key = "curios.identifier." + slots.get(j);
-          IFormattableTextComponent type = new TranslationTextComponent(key);
+		for (int j = 0; j < slots.size(); j++) {
+		  String key = "curios.identifier." + slots.get(j);
+		  IFormattableTextComponent type = new TranslationTextComponent(key);
 
-          if (j < slots.size() - 1) {
-            type = type.appendString(", ");
-          }
+		  if (j < slots.size() - 1) {
+			type = type.appendString(", ");
+		  }
 
-          type = type.mergeStyle(TextFormatting.YELLOW);
-          slotsTooltip.append(type);
-        }
+		  type = type.mergeStyle(TextFormatting.YELLOW);
+		  slotsTooltip.append(type);
+		}
 
-        tagTooltips.add(slotsTooltip);
+		tagTooltips.add(slotsTooltip);
 
-        LazyOptional<ICurio> optionalCurio = CuriosApi.getCuriosHelper().getCurio(stack);
-        optionalCurio.ifPresent(curio -> {
-          List<ITextComponent> curioTagsTooltip = curio.getTagsTooltip(tagTooltips);
+		LazyOptional<ICurio> optionalCurio = CuriosApi.getCuriosHelper().getCurio(stack);
+		optionalCurio.ifPresent(curio -> {
+		  List<ITextComponent> curioTagsTooltip = curio.getTagsTooltip(tagTooltips);
 
-          if (!curioTagsTooltip.isEmpty()) {
-            tooltip.addAll(1, curio.getTagsTooltip(tagTooltips));
-          }
+		  if (!curioTagsTooltip.isEmpty()) {
+			tooltip.addAll(1, curio.getTagsTooltip(tagTooltips));
+		  }
 
-        });
+		});
 
-        if (!optionalCurio.isPresent()) {
-          tooltip.addAll(1, tagTooltips);
-        }
+		if (!optionalCurio.isPresent()) {
+		  tooltip.addAll(1, tagTooltips);
+		}
 
-        for (String identifier : slots) {
-          Multimap<Attribute, AttributeModifier> multimap = CuriosApi.getCuriosHelper()
-              .getAttributeModifiers(identifier, stack);
-          boolean addAttributeTooltips = optionalCurio
-              .map(iCurio -> iCurio.showAttributesTooltip(identifier)).orElse(true);
+		for (String identifier : slots) {
+		  Multimap<Attribute, AttributeModifier> multimap = CuriosApi.getCuriosHelper()
+			  .getAttributeModifiers(identifier, stack);
+		  boolean addAttributeTooltips = optionalCurio
+			  .map(iCurio -> iCurio.showAttributesTooltip(identifier, stack)).orElse(true);
 
-          if (addAttributeTooltips && !multimap.isEmpty() && (i & 2) == 0) {
-            PlayerEntity player = evt.getPlayer();
-            tooltip.add(StringTextComponent.EMPTY);
-            tooltip.add(new TranslationTextComponent("curios.modifiers." + identifier)
-                .mergeStyle(TextFormatting.GOLD));
+		  if (addAttributeTooltips && !multimap.isEmpty() && (i & 2) == 0) {
+			PlayerEntity player = evt.getPlayer();
+			tooltip.add(StringTextComponent.EMPTY);
+			tooltip.add(new TranslationTextComponent("curios.modifiers." + identifier)
+				.mergeStyle(TextFormatting.GOLD));
 
-            for (Map.Entry<Attribute, AttributeModifier> entry : multimap.entries()) {
-              AttributeModifier attributemodifier = entry.getValue();
-              double amount = attributemodifier.getAmount();
-              boolean flag = false;
+			for (Map.Entry<Attribute, AttributeModifier> entry : multimap.entries()) {
+			  AttributeModifier attributemodifier = entry.getValue();
+			  double amount = attributemodifier.getAmount();
+			  boolean flag = false;
 
-              if (player != null) {
+			  if (player != null) {
 
-                if (attributemodifier.getID() == ATTACK_DAMAGE_MODIFIER) {
-                  ModifiableAttributeInstance att = player.getAttribute(Attributes.ATTACK_DAMAGE);
+				if (attributemodifier.getID() == ATTACK_DAMAGE_MODIFIER) {
+				  ModifiableAttributeInstance att = player.getAttribute(Attributes.ATTACK_DAMAGE);
 
-                  if (att != null) {
-                    amount = amount + att.getBaseValue();
-                  }
-                  amount = amount + EnchantmentHelper
-                      .getModifierForCreature(stack, CreatureAttribute.UNDEFINED);
-                  flag = true;
-                } else if (attributemodifier.getID() == ATTACK_SPEED_MODIFIER) {
-                  ModifiableAttributeInstance att = player.getAttribute(Attributes.ATTACK_SPEED);
+				  if (att != null) {
+					amount = amount + att.getBaseValue();
+				  }
+				  amount = amount + EnchantmentHelper
+					  .getModifierForCreature(stack, CreatureAttribute.UNDEFINED);
+				  flag = true;
+				} else if (attributemodifier.getID() == ATTACK_SPEED_MODIFIER) {
+				  ModifiableAttributeInstance att = player.getAttribute(Attributes.ATTACK_SPEED);
 
-                  if (att != null) {
-                    amount += att.getBaseValue();
-                  }
-                  flag = true;
-                }
+				  if (att != null) {
+					amount += att.getBaseValue();
+				  }
+				  flag = true;
+				}
 
-                double d1;
+				double d1;
 
-                if (attributemodifier.getOperation() != AttributeModifier.Operation.MULTIPLY_BASE
-                    && attributemodifier.getOperation()
-                    != AttributeModifier.Operation.MULTIPLY_TOTAL) {
-                  d1 = amount;
-                } else {
-                  d1 = amount * 100.0D;
-                }
+				if (attributemodifier.getOperation() != AttributeModifier.Operation.MULTIPLY_BASE
+					&& attributemodifier.getOperation()
+					!= AttributeModifier.Operation.MULTIPLY_TOTAL) {
+				  d1 = amount;
+				} else {
+				  d1 = amount * 100.0D;
+				}
 
-                if (flag) {
-                  tooltip.add((new StringTextComponent(" ")).append(new TranslationTextComponent(
-                      "attribute.modifier.equals." + attributemodifier.getOperation().getId(),
-                      DECIMALFORMAT.format(d1),
-                      new TranslationTextComponent(entry.getKey().func_233754_c_())))
-                      .mergeStyle(TextFormatting.DARK_GREEN));
-                } else if (amount > 0.0D) {
-                  tooltip.add((new TranslationTextComponent(
-                      "attribute.modifier.plus." + attributemodifier.getOperation().getId(),
-                      DECIMALFORMAT.format(d1),
-                      new TranslationTextComponent(entry.getKey().func_233754_c_())))
-                      .mergeStyle(TextFormatting.BLUE));
-                } else if (amount < 0.0D) {
-                  d1 = d1 * -1.0D;
-                  tooltip.add((new TranslationTextComponent(
-                      "attribute.modifier.take." + attributemodifier.getOperation().getId(),
-                      DECIMALFORMAT.format(d1),
-                      new TranslationTextComponent(entry.getKey().func_233754_c_())))
-                      .mergeStyle(TextFormatting.RED));
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+				if (flag) {
+				  tooltip.add((new StringTextComponent(" ")).append(new TranslationTextComponent(
+					  "attribute.modifier.equals." + attributemodifier.getOperation().getId(),
+					  DECIMALFORMAT.format(d1),
+					  new TranslationTextComponent(entry.getKey().func_233754_c_())))
+					  .mergeStyle(TextFormatting.DARK_GREEN));
+				} else if (amount > 0.0D) {
+				  tooltip.add((new TranslationTextComponent(
+					  "attribute.modifier.plus." + attributemodifier.getOperation().getId(),
+					  DECIMALFORMAT.format(d1),
+					  new TranslationTextComponent(entry.getKey().func_233754_c_())))
+					  .mergeStyle(TextFormatting.BLUE));
+				} else if (amount < 0.0D) {
+				  d1 = d1 * -1.0D;
+				  tooltip.add((new TranslationTextComponent(
+					  "attribute.modifier.take." + attributemodifier.getOperation().getId(),
+					  DECIMALFORMAT.format(d1),
+					  new TranslationTextComponent(entry.getKey().func_233754_c_())))
+					  .mergeStyle(TextFormatting.RED));
+				}
+			  }
+			}
+		  }
+		}
+	  }
+	}
   }
 }

--- a/src/main/java/top/theillusivec4/curios/client/render/CuriosLayer.java
+++ b/src/main/java/top/theillusivec4/curios/client/render/CuriosLayer.java
@@ -31,44 +31,45 @@ import top.theillusivec4.curios.api.CuriosApi;
 import top.theillusivec4.curios.api.type.inventory.IDynamicStackHandler;
 
 public class CuriosLayer<T extends LivingEntity, M extends EntityModel<T>> extends
-    LayerRenderer<T, M> {
+LayerRenderer<T, M> {
 
   public CuriosLayer(IEntityRenderer<T, M> renderer) {
-    super(renderer);
+	super(renderer);
   }
 
   @Override
   public void render(@Nonnull MatrixStack matrixStack, @Nonnull IRenderTypeBuffer renderTypeBuffer,
-      int light, @Nonnull T livingEntity, float limbSwing, float limbSwingAmount,
-      float partialTicks, float ageInTicks, float netHeadYaw, float headPitch) {
-    matrixStack.push();
-    CuriosApi.getCuriosHelper().getCuriosHandler(livingEntity)
-        .ifPresent(handler -> handler.getCurios().forEach((id, stacksHandler) -> {
-          IDynamicStackHandler stackHandler = stacksHandler.getStacks();
-          IDynamicStackHandler cosmeticStacksHandler = stacksHandler.getCosmeticStacks();
+	  int light, @Nonnull T livingEntity, float limbSwing, float limbSwingAmount,
+	  float partialTicks, float ageInTicks, float netHeadYaw, float headPitch) {
+	matrixStack.push();
+	CuriosApi.getCuriosHelper().getCuriosHandler(livingEntity)
+	.ifPresent(handler -> handler.getCurios().forEach((id, stacksHandler) -> {
+	  IDynamicStackHandler stackHandler = stacksHandler.getStacks();
+	  IDynamicStackHandler cosmeticStacksHandler = stacksHandler.getCosmeticStacks();
 
-          for (int i = 0; i < stackHandler.getSlots(); i++) {
-            ItemStack stack = cosmeticStacksHandler.getStackInSlot(i);
+	  for (int i = 0; i < stackHandler.getSlots(); i++) {
+		ItemStack stack = cosmeticStacksHandler.getStackInSlot(i);
 
-            if (stack.isEmpty() && stacksHandler.getRenders().get(i)) {
-              stack = stackHandler.getStackInSlot(i);
-            }
+		if (stack.isEmpty() && stacksHandler.getRenders().get(i)) {
+		  stack = stackHandler.getStackInSlot(i);
+		}
 
-            if (!stack.isEmpty()) {
-              int index = i;
+		if (!stack.isEmpty()) {
+		  int index = i;
 
-              CuriosApi.getCuriosHelper().getCurio(stack).ifPresent(curio -> {
+		  final ItemStack finalStack = stack;
+		  CuriosApi.getCuriosHelper().getCurio(finalStack).ifPresent(curio -> {
 
-                if (curio.canRender(id, index, livingEntity)) {
-                  matrixStack.push();
-                  curio.render(id, index, matrixStack, renderTypeBuffer, light, livingEntity,
-                      limbSwing, limbSwingAmount, partialTicks, ageInTicks, netHeadYaw, headPitch);
-                  matrixStack.pop();
-                }
-              });
-            }
-          }
-        }));
-    matrixStack.pop();
+			if (curio.canRender(id, index, livingEntity, finalStack)) {
+			  matrixStack.push();
+			  curio.render(id, index, matrixStack, renderTypeBuffer, light, livingEntity,
+				  limbSwing, limbSwingAmount, partialTicks, ageInTicks, netHeadYaw, headPitch, finalStack);
+			  matrixStack.pop();
+			}
+		  });
+		}
+	  }
+	}));
+	matrixStack.pop();
   }
 }

--- a/src/main/java/top/theillusivec4/curios/common/CuriosHelper.java
+++ b/src/main/java/top/theillusivec4/curios/common/CuriosHelper.java
@@ -55,115 +55,114 @@ public class CuriosHelper implements ICuriosHelper {
 
   @Override
   public LazyOptional<ICurio> getCurio(ItemStack stack) {
-    return stack.getCapability(CuriosCapability.ITEM);
+	return stack.getCapability(CuriosCapability.ITEM);
   }
 
   @Override
   public LazyOptional<ICuriosItemHandler> getCuriosHandler(
-      @Nonnull final LivingEntity livingEntity) {
-    return livingEntity.getCapability(CuriosCapability.INVENTORY);
+	  @Nonnull final LivingEntity livingEntity) {
+	return livingEntity.getCapability(CuriosCapability.INVENTORY);
   }
 
   @Override
   public Set<String> getCurioTags(Item item) {
-    return item.getTags().stream().filter(tag -> tag.getNamespace().equals(CuriosApi.MODID))
-        .map(ResourceLocation::getPath).collect(Collectors.toSet());
+	return item.getTags().stream().filter(tag -> tag.getNamespace().equals(CuriosApi.MODID))
+		.map(ResourceLocation::getPath).collect(Collectors.toSet());
   }
 
   @Override
   public LazyOptional<IItemHandlerModifiable> getEquippedCurios(LivingEntity livingEntity) {
-    return CuriosApi.getCuriosHelper().getCuriosHandler(livingEntity).lazyMap(handler -> {
-      Map<String, ICurioStacksHandler> curios = handler.getCurios();
-      IItemHandlerModifiable[] itemHandlers = new IItemHandlerModifiable[curios.size()];
-      int index = 0;
+	return CuriosApi.getCuriosHelper().getCuriosHandler(livingEntity).lazyMap(handler -> {
+	  Map<String, ICurioStacksHandler> curios = handler.getCurios();
+	  IItemHandlerModifiable[] itemHandlers = new IItemHandlerModifiable[curios.size()];
+	  int index = 0;
 
-      for (ICurioStacksHandler stacksHandler : curios.values()) {
+	  for (ICurioStacksHandler stacksHandler : curios.values()) {
 
-        if (index < itemHandlers.length) {
-          itemHandlers[index] = stacksHandler.getStacks();
-          index++;
-        }
-      }
-      return new CombinedInvWrapper(itemHandlers);
-    });
+		if (index < itemHandlers.length) {
+		  itemHandlers[index] = stacksHandler.getStacks();
+		  index++;
+		}
+	  }
+	  return new CombinedInvWrapper(itemHandlers);
+	});
   }
 
   @Override
   public Optional<ImmutableTriple<String, Integer, ItemStack>> findEquippedCurio(Item item,
-      @Nonnull final LivingEntity livingEntity) {
-    return findEquippedCurio((stack) -> stack.getItem() == item, livingEntity);
+	  @Nonnull final LivingEntity livingEntity) {
+	return this.findEquippedCurio((stack) -> stack.getItem() == item, livingEntity);
   }
 
   @Nonnull
   @Override
   public Optional<ImmutableTriple<String, Integer, ItemStack>> findEquippedCurio(
-      Predicate<ItemStack> filter, @Nonnull final LivingEntity livingEntity) {
+	  Predicate<ItemStack> filter, @Nonnull final LivingEntity livingEntity) {
 
-    ImmutableTriple<String, Integer, ItemStack> result = getCuriosHandler(livingEntity)
-        .map(handler -> {
-          Map<String, ICurioStacksHandler> curios = handler.getCurios();
+	ImmutableTriple<String, Integer, ItemStack> result = this.getCuriosHandler(livingEntity)
+		.map(handler -> {
+		  Map<String, ICurioStacksHandler> curios = handler.getCurios();
 
-          for (String id : curios.keySet()) {
-            ICurioStacksHandler stacksHandler = curios.get(id);
-            IDynamicStackHandler stackHandler = stacksHandler.getStacks();
+		  for (String id : curios.keySet()) {
+			ICurioStacksHandler stacksHandler = curios.get(id);
+			IDynamicStackHandler stackHandler = stacksHandler.getStacks();
 
-            for (int i = 0; i < stackHandler.getSlots(); i++) {
-              ItemStack stack = stackHandler.getStackInSlot(i);
+			for (int i = 0; i < stackHandler.getSlots(); i++) {
+			  ItemStack stack = stackHandler.getStackInSlot(i);
 
-              if (!stack.isEmpty() && filter.test(stack)) {
-                return new ImmutableTriple<>(id, i, stack);
-              }
-            }
-          }
-          return new ImmutableTriple<>("", 0, ItemStack.EMPTY);
-        }).orElse(new ImmutableTriple<>("", 0, ItemStack.EMPTY));
+			  if (!stack.isEmpty() && filter.test(stack))
+				return new ImmutableTriple<>(id, i, stack);
+			}
+		  }
+		  return new ImmutableTriple<>("", 0, ItemStack.EMPTY);
+		}).orElse(new ImmutableTriple<>("", 0, ItemStack.EMPTY));
 
-    return result.getLeft().isEmpty() ? Optional.empty() : Optional.of(result);
+	return result.getLeft().isEmpty() ? Optional.empty() : Optional.of(result);
   }
 
   @Override
   public Multimap<Attribute, AttributeModifier> getAttributeModifiers(String identifier,
-      ItemStack stack) {
-    Multimap<Attribute, AttributeModifier> multimap;
+	  ItemStack stack) {
+	Multimap<Attribute, AttributeModifier> multimap;
 
-    if (stack.getTag() != null && stack.getTag().contains("CurioAttributeModifiers", 9)) {
-      multimap = HashMultimap.create();
-      ListNBT listnbt = stack.getTag().getList("CurioAttributeModifiers", 10);
+	if (stack.getTag() != null && stack.getTag().contains("CurioAttributeModifiers", 9)) {
+	  multimap = HashMultimap.create();
+	  ListNBT listnbt = stack.getTag().getList("CurioAttributeModifiers", 10);
 
-      for (int i = 0; i < listnbt.size(); ++i) {
-        CompoundNBT compoundnbt = listnbt.getCompound(i);
+	  for (int i = 0; i < listnbt.size(); ++i) {
+		CompoundNBT compoundnbt = listnbt.getCompound(i);
 
-        if (!compoundnbt.contains("Slot", 8) || compoundnbt.getString("Slot").equals(identifier)) {
-          Attribute attribute = ForgeRegistries.ATTRIBUTES
-              .getValue(ResourceLocation.tryCreate(compoundnbt.getString("AttributeName")));
+		if (!compoundnbt.contains("Slot", 8) || compoundnbt.getString("Slot").equals(identifier)) {
+		  Attribute attribute = ForgeRegistries.ATTRIBUTES
+			  .getValue(ResourceLocation.tryCreate(compoundnbt.getString("AttributeName")));
 
-          if (attribute != null) {
-            AttributeModifier attributemodifier = AttributeModifier.func_233800_a_(compoundnbt);
+		  if (attribute != null) {
+			AttributeModifier attributemodifier = AttributeModifier.func_233800_a_(compoundnbt);
 
-            if (attributemodifier != null
-                && attributemodifier.getID().getLeastSignificantBits() != 0L
-                && attributemodifier.getID().getMostSignificantBits() != 0L) {
-              multimap.put(attribute, attributemodifier);
-            }
-          }
-        }
-      }
-      return multimap;
-    }
-    return getCurio(stack).map(curio -> curio.getAttributeModifiers(identifier))
-        .orElse(HashMultimap.create());
+			if (attributemodifier != null
+				&& attributemodifier.getID().getLeastSignificantBits() != 0L
+				&& attributemodifier.getID().getMostSignificantBits() != 0L) {
+			  multimap.put(attribute, attributemodifier);
+			}
+		  }
+		}
+	  }
+	  return multimap;
+	}
+	return this.getCurio(stack).map(curio -> curio.getAttributeModifiers(identifier, stack))
+		.orElse(HashMultimap.create());
   }
 
   @Override
   public void onBrokenCurio(String id, int index, LivingEntity damager) {
-    brokenCurioConsumer.accept(id, index, damager);
+	brokenCurioConsumer.accept(id, index, damager);
   }
 
   @Override
   public void setBrokenCurioConsumer(TriConsumer<String, Integer, LivingEntity> consumer) {
 
-    if (brokenCurioConsumer == null) {
-      brokenCurioConsumer = consumer;
-    }
+	if (brokenCurioConsumer == null) {
+	  brokenCurioConsumer = consumer;
+	}
   }
 }

--- a/src/main/java/top/theillusivec4/curios/common/capability/CurioInventoryCapability.java
+++ b/src/main/java/top/theillusivec4/curios/common/capability/CurioInventoryCapability.java
@@ -59,331 +59,331 @@ import top.theillusivec4.curios.common.inventory.CurioStacksHandler;
 public class CurioInventoryCapability {
 
   public static void register() {
-    CapabilityManager.INSTANCE
-        .register(ICuriosItemHandler.class, new Capability.IStorage<ICuriosItemHandler>() {
-          @Override
-          public INBT writeNBT(Capability<ICuriosItemHandler> capability,
-              ICuriosItemHandler instance, Direction side) {
-            CompoundNBT compound = new CompoundNBT();
+	CapabilityManager.INSTANCE
+	.register(ICuriosItemHandler.class, new Capability.IStorage<ICuriosItemHandler>() {
+	  @Override
+	  public INBT writeNBT(Capability<ICuriosItemHandler> capability,
+		  ICuriosItemHandler instance, Direction side) {
+		CompoundNBT compound = new CompoundNBT();
 
-            ListNBT taglist = new ListNBT();
-            instance.getCurios().forEach((key, stacksHandler) -> {
-              CompoundNBT tag = new CompoundNBT();
-              tag.put("StacksHandler", stacksHandler.serializeNBT());
-              tag.putString("Identifier", key);
-              taglist.add(tag);
-            });
-            compound.put("Curios", taglist);
+		ListNBT taglist = new ListNBT();
+		instance.getCurios().forEach((key, stacksHandler) -> {
+		  CompoundNBT tag = new CompoundNBT();
+		  tag.put("StacksHandler", stacksHandler.serializeNBT());
+		  tag.putString("Identifier", key);
+		  taglist.add(tag);
+		});
+		compound.put("Curios", taglist);
 
-            ListNBT taglist1 = new ListNBT();
+		ListNBT taglist1 = new ListNBT();
 
-            for (String identifier : instance.getLockedSlots()) {
-              taglist1.add(StringNBT.valueOf(identifier));
-            }
-            compound.put("Locked", taglist1);
-            return compound;
-          }
+		for (String identifier : instance.getLockedSlots()) {
+		  taglist1.add(StringNBT.valueOf(identifier));
+		}
+		compound.put("Locked", taglist1);
+		return compound;
+	  }
 
-          @Override
-          public void readNBT(Capability<ICuriosItemHandler> capability,
-              ICuriosItemHandler instance, Direction side, INBT nbt) {
-            ListNBT tagList = ((CompoundNBT) nbt).getList("Curios", NBT.TAG_COMPOUND);
-            ListNBT lockedList = ((CompoundNBT) nbt).getList("Locked", NBT.TAG_STRING);
+	  @Override
+	  public void readNBT(Capability<ICuriosItemHandler> capability,
+		  ICuriosItemHandler instance, Direction side, INBT nbt) {
+		ListNBT tagList = ((CompoundNBT) nbt).getList("Curios", NBT.TAG_COMPOUND);
+		ListNBT lockedList = ((CompoundNBT) nbt).getList("Locked", NBT.TAG_STRING);
 
-            if (!tagList.isEmpty()) {
-              Map<String, ICurioStacksHandler> curios = new LinkedHashMap<>();
-              SortedMap<ISlotType, ICurioStacksHandler> sortedCurios = CuriosApi.getSlotHelper()
-                  .createSlots();
+		if (!tagList.isEmpty()) {
+		  Map<String, ICurioStacksHandler> curios = new LinkedHashMap<>();
+		  SortedMap<ISlotType, ICurioStacksHandler> sortedCurios = CuriosApi.getSlotHelper()
+			  .createSlots();
 
-              for (int i = 0; i < tagList.size(); i++) {
-                CompoundNBT tag = tagList.getCompound(i);
-                String identifier = tag.getString("Identifier");
-                CurioStacksHandler prevStacksHandler = new CurioStacksHandler();
-                prevStacksHandler.deserializeNBT(tag.getCompound("StacksHandler"));
+		  for (int i = 0; i < tagList.size(); i++) {
+			CompoundNBT tag = tagList.getCompound(i);
+			String identifier = tag.getString("Identifier");
+			CurioStacksHandler prevStacksHandler = new CurioStacksHandler();
+			prevStacksHandler.deserializeNBT(tag.getCompound("StacksHandler"));
 
-                Optional<ISlotType> optionalType = CuriosApi.getSlotHelper()
-                    .getSlotType(identifier);
-                optionalType.ifPresent(type -> {
-                  CurioStacksHandler newStacksHandler = new CurioStacksHandler(type.getSize(),
-                      prevStacksHandler.getSizeShift(), type.isVisible(), type.hasCosmetic());
-                  int index = 0;
+			Optional<ISlotType> optionalType = CuriosApi.getSlotHelper()
+				.getSlotType(identifier);
+			optionalType.ifPresent(type -> {
+			  CurioStacksHandler newStacksHandler = new CurioStacksHandler(type.getSize(),
+				  prevStacksHandler.getSizeShift(), type.isVisible(), type.hasCosmetic());
+			  int index = 0;
 
-                  while (index < newStacksHandler.getSlots() && index < prevStacksHandler
-                      .getSlots()) {
-                    newStacksHandler.getStacks()
-                        .setStackInSlot(index, prevStacksHandler.getStacks().getStackInSlot(index));
-                    newStacksHandler.getCosmeticStacks().setStackInSlot(index,
-                        prevStacksHandler.getCosmeticStacks().getStackInSlot(index));
-                    index++;
-                  }
+			  while (index < newStacksHandler.getSlots() && index < prevStacksHandler
+				  .getSlots()) {
+				newStacksHandler.getStacks()
+				.setStackInSlot(index, prevStacksHandler.getStacks().getStackInSlot(index));
+				newStacksHandler.getCosmeticStacks().setStackInSlot(index,
+					prevStacksHandler.getCosmeticStacks().getStackInSlot(index));
+				index++;
+			  }
 
-                  while (index < prevStacksHandler.getSlots()) {
-                    instance.loseInvalidStack(prevStacksHandler.getStacks().getStackInSlot(index));
-                    instance.loseInvalidStack(
-                        prevStacksHandler.getCosmeticStacks().getStackInSlot(index));
-                    index++;
-                  }
-                  sortedCurios.put(type, newStacksHandler);
+			  while (index < prevStacksHandler.getSlots()) {
+				instance.loseInvalidStack(prevStacksHandler.getStacks().getStackInSlot(index));
+				instance.loseInvalidStack(
+					prevStacksHandler.getCosmeticStacks().getStackInSlot(index));
+				index++;
+			  }
+			  sortedCurios.put(type, newStacksHandler);
 
-                  for (int j = 0;
-                      j < newStacksHandler.getRenders().size() && j < prevStacksHandler.getRenders()
-                          .size(); j++) {
-                    newStacksHandler.getRenders().set(j, prevStacksHandler.getRenders().get(j));
-                  }
-                });
+			  for (int j = 0;
+				  j < newStacksHandler.getRenders().size() && j < prevStacksHandler.getRenders()
+				  .size(); j++) {
+				newStacksHandler.getRenders().set(j, prevStacksHandler.getRenders().get(j));
+			  }
+			});
 
-                if (!optionalType.isPresent()) {
-                  IDynamicStackHandler stackHandler = prevStacksHandler.getStacks();
-                  IDynamicStackHandler cosmeticStackHandler = prevStacksHandler.getCosmeticStacks();
+			if (!optionalType.isPresent()) {
+			  IDynamicStackHandler stackHandler = prevStacksHandler.getStacks();
+			  IDynamicStackHandler cosmeticStackHandler = prevStacksHandler.getCosmeticStacks();
 
-                  for (int j = 0; j < stackHandler.getSlots(); j++) {
-                    ItemStack stack = stackHandler.getStackInSlot(j);
+			  for (int j = 0; j < stackHandler.getSlots(); j++) {
+				ItemStack stack = stackHandler.getStackInSlot(j);
 
-                    if (!stack.isEmpty()) {
-                      instance.loseInvalidStack(stack);
-                    }
+				if (!stack.isEmpty()) {
+				  instance.loseInvalidStack(stack);
+				}
 
-                    ItemStack cosmeticStack = cosmeticStackHandler.getStackInSlot(j);
+				ItemStack cosmeticStack = cosmeticStackHandler.getStackInSlot(j);
 
-                    if (!cosmeticStack.isEmpty()) {
-                      instance.loseInvalidStack(cosmeticStack);
-                    }
-                  }
-                }
-              }
-              sortedCurios.forEach(
-                  (slotType, stacksHandler) -> curios.put(slotType.getIdentifier(), stacksHandler));
-              instance.setCurios(curios);
+				if (!cosmeticStack.isEmpty()) {
+				  instance.loseInvalidStack(cosmeticStack);
+				}
+			  }
+			}
+		  }
+		  sortedCurios.forEach(
+			  (slotType, stacksHandler) -> curios.put(slotType.getIdentifier(), stacksHandler));
+		  instance.setCurios(curios);
 
-              for (int k = 0; k < lockedList.size(); k++) {
-                instance.lockSlotType(lockedList.getString(k));
-              }
-            }
-          }
-        }, CurioInventoryWrapper::new);
+		  for (int k = 0; k < lockedList.size(); k++) {
+			instance.lockSlotType(lockedList.getString(k));
+		  }
+		}
+	  }
+	}, CurioInventoryWrapper::new);
   }
 
   public static ICapabilityProvider createProvider(final PlayerEntity playerEntity) {
-    return new Provider(playerEntity);
+	return new Provider(playerEntity);
   }
 
   public static class CurioInventoryWrapper implements ICuriosItemHandler {
-    Map<String, ICurioStacksHandler> curios = new LinkedHashMap<>();
-    Set<String> locked = new HashSet<>();
-    NonNullList<ItemStack> invalidStacks = NonNullList.create();
-    PlayerEntity wearer;
-    Set<String> toLock = new HashSet<>();
-    List<UnlockState> toUnlock = new ArrayList<>();
-    Tuple<Integer, Integer> fortuneAndLooting = new Tuple<Integer, Integer>(0, 0);
+	Map<String, ICurioStacksHandler> curios = new LinkedHashMap<>();
+	Set<String> locked = new HashSet<>();
+	NonNullList<ItemStack> invalidStacks = NonNullList.create();
+	PlayerEntity wearer;
+	Set<String> toLock = new HashSet<>();
+	List<UnlockState> toUnlock = new ArrayList<>();
+	Tuple<Integer, Integer> fortuneAndLooting = new Tuple<Integer, Integer>(0, 0);
 
-    CurioInventoryWrapper() {
-      this(null);
-    }
+	CurioInventoryWrapper() {
+	  this(null);
+	}
 
-    CurioInventoryWrapper(final PlayerEntity playerEntity) {
-      this.wearer = playerEntity;
-      this.reset();
-    }
+	CurioInventoryWrapper(final PlayerEntity playerEntity) {
+	  this.wearer = playerEntity;
+	  this.reset();
+	}
 
-    @Override
-    public void reset() {
+	@Override
+	public void reset() {
 
-      if (!this.wearer.getEntityWorld().isRemote() && this.wearer instanceof ServerPlayerEntity) {
-        this.locked.clear();
-        this.curios.clear();
-        this.invalidStacks.clear();
-        CuriosApi.getSlotHelper().createSlots().forEach(
-            ((slotType, stacksHandler) -> this.curios.put(slotType.getIdentifier(), stacksHandler)));
-      }
-    }
+	  if (!this.wearer.getEntityWorld().isRemote() && this.wearer instanceof ServerPlayerEntity) {
+		this.locked.clear();
+		this.curios.clear();
+		this.invalidStacks.clear();
+		CuriosApi.getSlotHelper().createSlots().forEach(
+			((slotType, stacksHandler) -> this.curios.put(slotType.getIdentifier(), stacksHandler)));
+	  }
+	}
 
-    @Override
-    public int getSlots() {
-      int totalSlots = 0;
+	@Override
+	public int getSlots() {
+	  int totalSlots = 0;
 
-      for (ICurioStacksHandler stacks : this.curios.values()) {
-        totalSlots += stacks.getSlots();
-      }
-      return totalSlots;
-    }
+	  for (ICurioStacksHandler stacks : this.curios.values()) {
+		totalSlots += stacks.getSlots();
+	  }
+	  return totalSlots;
+	}
 
-    @Override
-    public int getVisibleSlots() {
-      int totalSlots = 0;
+	@Override
+	public int getVisibleSlots() {
+	  int totalSlots = 0;
 
-      for (ICurioStacksHandler stacks : this.curios.values()) {
+	  for (ICurioStacksHandler stacks : this.curios.values()) {
 
-        if (stacks.isVisible()) {
-          totalSlots += stacks.getSlots();
-        }
-      }
-      return totalSlots;
-    }
+		if (stacks.isVisible()) {
+		  totalSlots += stacks.getSlots();
+		}
+	  }
+	  return totalSlots;
+	}
 
-    @Override
-    public Set<String> getLockedSlots() {
-      return Collections.unmodifiableSet(this.locked);
-    }
+	@Override
+	public Set<String> getLockedSlots() {
+	  return Collections.unmodifiableSet(this.locked);
+	}
 
-    @Override
-    public Optional<ICurioStacksHandler> getStacksHandler(String identifier) {
-      return Optional.ofNullable(this.curios.get(identifier));
-    }
+	@Override
+	public Optional<ICurioStacksHandler> getStacksHandler(String identifier) {
+	  return Optional.ofNullable(this.curios.get(identifier));
+	}
 
-    @Override
-    public Map<String, ICurioStacksHandler> getCurios() {
-      return Collections.unmodifiableMap(this.curios);
-    }
+	@Override
+	public Map<String, ICurioStacksHandler> getCurios() {
+	  return Collections.unmodifiableMap(this.curios);
+	}
 
-    @Override
-    public void setCurios(Map<String, ICurioStacksHandler> curios) {
-      this.curios = curios;
-    }
+	@Override
+	public void setCurios(Map<String, ICurioStacksHandler> curios) {
+	  this.curios = curios;
+	}
 
-    @Override
-    public void unlockSlotType(String identifier, int amount, boolean visible, boolean cosmetic) {
-      this.toUnlock.add(new UnlockState(identifier, amount, visible, cosmetic));
-    }
+	@Override
+	public void unlockSlotType(String identifier, int amount, boolean visible, boolean cosmetic) {
+	  this.toUnlock.add(new UnlockState(identifier, amount, visible, cosmetic));
+	}
 
-    @Override
-    public void lockSlotType(String identifier) {
-      this.toLock.add(identifier);
-    }
+	@Override
+	public void lockSlotType(String identifier) {
+	  this.toLock.add(identifier);
+	}
 
-    @Override
-    public void processSlots() {
-      this.toLock.forEach(id -> this.getStacksHandler(id).ifPresent(stackHandler -> {
-        this.curios.remove(id);
-        this.locked.add(id);
-        this.loseStacks(stackHandler.getStacks(), id, stackHandler.getSlots());
-      }));
-      this.toUnlock.forEach(state -> {
-        this.curios.putIfAbsent(state.identifier,
-            new CurioStacksHandler(state.amount, 0, state.visible, state.cosmetic));
-        this.locked.remove(state.identifier);
-      });
-      this.toLock.clear();
-      this.toUnlock.clear();
-    }
+	@Override
+	public void processSlots() {
+	  this.toLock.forEach(id -> this.getStacksHandler(id).ifPresent(stackHandler -> {
+		this.curios.remove(id);
+		this.locked.add(id);
+		this.loseStacks(stackHandler.getStacks(), id, stackHandler.getSlots());
+	  }));
+	  this.toUnlock.forEach(state -> {
+		this.curios.putIfAbsent(state.identifier,
+			new CurioStacksHandler(state.amount, 0, state.visible, state.cosmetic));
+		this.locked.remove(state.identifier);
+	  });
+	  this.toLock.clear();
+	  this.toUnlock.clear();
+	}
 
-    @Override
-    public void growSlotType(String identifier, int amount) {
+	@Override
+	public void growSlotType(String identifier, int amount) {
 
-      if (amount > 0) {
-        this.getStacksHandler(identifier).ifPresent(stackHandler -> stackHandler.grow(amount));
-      }
-    }
+	  if (amount > 0) {
+		this.getStacksHandler(identifier).ifPresent(stackHandler -> stackHandler.grow(amount));
+	  }
+	}
 
-    @Override
-    public void shrinkSlotType(String identifier, int amount) {
+	@Override
+	public void shrinkSlotType(String identifier, int amount) {
 
-      if (amount > 0) {
-        this.getStacksHandler(identifier).ifPresent(stackHandler -> {
-          int toShrink = Math.min(stackHandler.getSlots() - 1, amount);
-          this.loseStacks(stackHandler.getStacks(), identifier, toShrink);
-          stackHandler.shrink(amount);
-        });
-      }
-    }
+	  if (amount > 0) {
+		this.getStacksHandler(identifier).ifPresent(stackHandler -> {
+		  int toShrink = Math.min(stackHandler.getSlots() - 1, amount);
+		  this.loseStacks(stackHandler.getStacks(), identifier, toShrink);
+		  stackHandler.shrink(amount);
+		});
+	  }
+	}
 
-    @Nullable
-    @Override
-    public LivingEntity getWearer() {
-      return this.wearer;
-    }
+	@Nullable
+	@Override
+	public LivingEntity getWearer() {
+	  return this.wearer;
+	}
 
-    @Override
-    public void loseInvalidStack(ItemStack stack) {
-      this.invalidStacks.add(stack);
-    }
+	@Override
+	public void loseInvalidStack(ItemStack stack) {
+	  this.invalidStacks.add(stack);
+	}
 
-    @Override
-    public void handleInvalidStacks() {
+	@Override
+	public void handleInvalidStacks() {
 
-      if (this.wearer != null && !this.invalidStacks.isEmpty()) {
-        this.invalidStacks.forEach(drop -> ItemHandlerHelper.giveItemToPlayer(this.wearer, drop));
-        this.invalidStacks = NonNullList.create();
-      }
-    }
+	  if (this.wearer != null && !this.invalidStacks.isEmpty()) {
+		this.invalidStacks.forEach(drop -> ItemHandlerHelper.giveItemToPlayer(this.wearer, drop));
+		this.invalidStacks = NonNullList.create();
+	  }
+	}
 
-    private void loseStacks(IDynamicStackHandler stackHandler, String identifier, int amount) {
+	private void loseStacks(IDynamicStackHandler stackHandler, String identifier, int amount) {
 
-      if (this.wearer != null && !this.wearer.getEntityWorld().isRemote()) {
-        List<ItemStack> drops = new ArrayList<>();
+	  if (this.wearer != null && !this.wearer.getEntityWorld().isRemote()) {
+		List<ItemStack> drops = new ArrayList<>();
 
-        for (int i = stackHandler.getSlots() - amount; i < stackHandler.getSlots(); i++) {
-          ItemStack stack = stackHandler.getStackInSlot(i);
-          drops.add(stackHandler.getStackInSlot(i));
+		for (int i = stackHandler.getSlots() - amount; i < stackHandler.getSlots(); i++) {
+		  ItemStack stack = stackHandler.getStackInSlot(i);
+		  drops.add(stackHandler.getStackInSlot(i));
 
-          if (!stack.isEmpty()) {
-            this.wearer.getAttributeManager().removeModifiers(
-                CuriosApi.getCuriosHelper().getAttributeModifiers(identifier, stack));
-            int index = i;
-            CuriosApi.getCuriosHelper().getCurio(stack)
-                .ifPresent(curio -> curio.onUnequip(identifier, index, this.wearer));
-          }
-          stackHandler.setStackInSlot(i, ItemStack.EMPTY);
-        }
-        drops.forEach(drop -> ItemHandlerHelper.giveItemToPlayer(this.wearer, drop));
-      }
-    }
+		  if (!stack.isEmpty()) {
+			this.wearer.getAttributeManager().removeModifiers(
+				CuriosApi.getCuriosHelper().getAttributeModifiers(identifier, stack));
+			int index = i;
+			CuriosApi.getCuriosHelper().getCurio(stack)
+			.ifPresent(curio -> curio.onUnequip(identifier, index, this.wearer, stack));
+		  }
+		  stackHandler.setStackInSlot(i, ItemStack.EMPTY);
+		}
+		drops.forEach(drop -> ItemHandlerHelper.giveItemToPlayer(this.wearer, drop));
+	  }
+	}
 
-    public static class UnlockState {
+	public static class UnlockState {
 
-      final String identifier;
-      final int amount;
-      final boolean visible;
-      final boolean cosmetic;
+	  final String identifier;
+	  final int amount;
+	  final boolean visible;
+	  final boolean cosmetic;
 
-      UnlockState(String identifier, int amount, boolean visible, boolean cosmetic) {
-        this.identifier = identifier;
-        this.amount = amount;
-        this.visible = visible;
-        this.cosmetic = cosmetic;
-      }
-    }
+	  UnlockState(String identifier, int amount, boolean visible, boolean cosmetic) {
+		this.identifier = identifier;
+		this.amount = amount;
+		this.visible = visible;
+		this.cosmetic = cosmetic;
+	  }
+	}
 
 	@Override
 	public int getFortuneBonus() {
-		return this.fortuneAndLooting.getA();
+	  return this.fortuneAndLooting.getA();
 	}
 
 	@Override
 	public int getLootingBonus() {
-		return this.fortuneAndLooting.getB();
+	  return this.fortuneAndLooting.getB();
 	}
 
 	@Override
 	public void setEnchantmentBonuses(Tuple<Integer, Integer> fortuneAndLootingIn) {
-		this.fortuneAndLooting = fortuneAndLootingIn;
+	  this.fortuneAndLooting = fortuneAndLootingIn;
 	}
-	
+
   }
 
   public static class Provider implements ICapabilitySerializable<INBT> {
 
-    final LazyOptional<ICuriosItemHandler> optional;
-    final ICuriosItemHandler handler;
+	final LazyOptional<ICuriosItemHandler> optional;
+	final ICuriosItemHandler handler;
 
-    Provider(final PlayerEntity playerEntity) {
-      this.handler = new CurioInventoryWrapper(playerEntity);
-      this.optional = LazyOptional.of(() -> this.handler);
-    }
+	Provider(final PlayerEntity playerEntity) {
+	  this.handler = new CurioInventoryWrapper(playerEntity);
+	  this.optional = LazyOptional.of(() -> this.handler);
+	}
 
-    @Nonnull
-    @Override
-    public <T> LazyOptional<T> getCapability(@Nullable Capability<T> capability, Direction facing) {
-      return CuriosCapability.INVENTORY.orEmpty(capability, this.optional);
-    }
+	@Nonnull
+	@Override
+	public <T> LazyOptional<T> getCapability(@Nullable Capability<T> capability, Direction facing) {
+	  return CuriosCapability.INVENTORY.orEmpty(capability, this.optional);
+	}
 
-    @Override
-    public INBT serializeNBT() {
-      return CuriosCapability.INVENTORY.writeNBT(this.handler, null);
-    }
+	@Override
+	public INBT serializeNBT() {
+	  return CuriosCapability.INVENTORY.writeNBT(this.handler, null);
+	}
 
-    @Override
-    public void deserializeNBT(INBT nbt) {
-      CuriosCapability.INVENTORY.readNBT(this.handler, null, nbt);
-    }
+	@Override
+	public void deserializeNBT(INBT nbt) {
+	  CuriosCapability.INVENTORY.readNBT(this.handler, null, nbt);
+	}
   }
 }

--- a/src/main/java/top/theillusivec4/curios/common/inventory/CurioSlot.java
+++ b/src/main/java/top/theillusivec4/curios/common/inventory/CurioSlot.java
@@ -43,46 +43,47 @@ public class CurioSlot extends SlotItemHandler {
   private NonNullList<Boolean> renderStatuses;
 
   public CurioSlot(PlayerEntity player, IDynamicStackHandler handler, int index, String identifier,
-      int xPosition, int yPosition, NonNullList<Boolean> renders) {
-    super(handler, index, xPosition, yPosition);
-    this.identifier = identifier;
-    this.renderStatuses = renders;
-    this.player = player;
-    this.setBackground(PlayerContainer.LOCATION_BLOCKS_TEXTURE,
-        player.getEntityWorld().isRemote() ? CuriosApi.getIconHelper().getIcon(identifier)
-            : new ResourceLocation(Curios.MODID, "item/empty_curio_slot"));
+	  int xPosition, int yPosition, NonNullList<Boolean> renders) {
+	super(handler, index, xPosition, yPosition);
+	this.identifier = identifier;
+	this.renderStatuses = renders;
+	this.player = player;
+	this.setBackground(PlayerContainer.LOCATION_BLOCKS_TEXTURE,
+		player.getEntityWorld().isRemote() ? CuriosApi.getIconHelper().getIcon(identifier)
+			: new ResourceLocation(Curios.MODID, "item/empty_curio_slot"));
   }
 
   public String getIdentifier() {
-    return this.identifier;
+	return this.identifier;
   }
 
   public boolean getRenderStatus() {
-    return this.renderStatuses.get(this.getSlotIndex());
+	return this.renderStatuses.get(this.getSlotIndex());
   }
 
   @OnlyIn(Dist.CLIENT)
   public String getSlotName() {
-    return I18n.format("curios.identifier." + identifier);
+	return I18n.format("curios.identifier." + this.identifier);
   }
 
   @Override
   public boolean isItemValid(@Nonnull ItemStack stack) {
-    return hasValidTag(CuriosApi.getCuriosHelper().getCurioTags(stack.getItem())) && CuriosApi
-        .getCuriosHelper().getCurio(stack).map(curio -> curio.canEquip(identifier, player))
-        .orElse(true) && super.isItemValid(stack);
+	return this.hasValidTag(CuriosApi.getCuriosHelper().getCurioTags(stack.getItem())) && CuriosApi
+		.getCuriosHelper().getCurio(stack).map(curio -> curio.canEquip(this.identifier, this.player, stack))
+		.orElse(true) && super.isItemValid(stack);
   }
 
   protected boolean hasValidTag(Set<String> tags) {
-    return tags.contains(identifier) || tags.contains("curio");
+	return tags.contains(this.identifier) || tags.contains("curio");
   }
 
   @Override
   public boolean canTakeStack(PlayerEntity playerIn) {
-    ItemStack stack = this.getStack();
-    return (stack.isEmpty() || playerIn.isCreative() || !EnchantmentHelper.hasBindingCurse(stack))
-        && CuriosApi.getCuriosHelper().getCurio(stack)
-        .map(curio -> curio.canUnequip(identifier, playerIn)).orElse(true) && super
-        .canTakeStack(playerIn);
+	ItemStack stack = this.getStack();
+
+	return (stack.isEmpty() || playerIn.isCreative() || !EnchantmentHelper.hasBindingCurse(stack))
+		&& CuriosApi.getCuriosHelper().getCurio(stack)
+		.map(curio -> curio.canUnequip(this.identifier, playerIn, stack, this.getSlotIndex())).orElse(true) && super
+		.canTakeStack(playerIn);
   }
 }

--- a/src/main/java/top/theillusivec4/curios/common/item/AmuletItem.java
+++ b/src/main/java/top/theillusivec4/curios/common/item/AmuletItem.java
@@ -54,7 +54,7 @@ public class AmuletItem extends Item {
 	  private Object model;
 
 	  @Override
-	  public void curioTick(String identifier, int index, LivingEntity livingEntity) {
+	  public void curioTick(String identifier, int index, LivingEntity livingEntity, ItemStack stack) {
 
 		if (!livingEntity.getEntityWorld().isRemote && livingEntity.ticksExisted % 40 == 0) {
 		  livingEntity.addPotionEffect(new EffectInstance(Effects.REGENERATION, 80, 0, true, true));
@@ -62,7 +62,7 @@ public class AmuletItem extends Item {
 	  }
 
 	  @Override
-	  public boolean canRender(String identifier, int index, LivingEntity livingEntity) {
+	  public boolean canRender(String identifier, int index, LivingEntity livingEntity, ItemStack stack) {
 		return true;
 	  }
 
@@ -70,7 +70,7 @@ public class AmuletItem extends Item {
 	  public void render(String identifier, int index, MatrixStack matrixStack,
 		  IRenderTypeBuffer renderTypeBuffer, int light, LivingEntity livingEntity, float limbSwing,
 		  float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw,
-		  float headPitch) {
+		  float headPitch, ItemStack stack) {
 		ICurio.RenderHelper.translateIfSneaking(matrixStack, livingEntity);
 		ICurio.RenderHelper.rotateIfSneaking(matrixStack, livingEntity);
 

--- a/src/main/java/top/theillusivec4/curios/common/item/AmuletItem.java
+++ b/src/main/java/top/theillusivec4/curios/common/item/AmuletItem.java
@@ -41,55 +41,55 @@ import top.theillusivec4.curios.common.capability.CurioItemCapability;
 public class AmuletItem extends Item {
 
   private static final ResourceLocation AMULET_TEXTURE = new ResourceLocation(Curios.MODID,
-      "textures/entity/amulet.png");
+	  "textures/entity/amulet.png");
 
   public AmuletItem() {
-    super(new Item.Properties().group(ItemGroup.TOOLS).maxStackSize(1).defaultMaxDamage(0));
-    this.setRegistryName(Curios.MODID, "amulet");
+	super(new Item.Properties().group(ItemGroup.TOOLS).maxStackSize(1).defaultMaxDamage(0));
+	this.setRegistryName(Curios.MODID, "amulet");
   }
 
   @Override
   public ICapabilityProvider initCapabilities(ItemStack stack, CompoundNBT unused) {
-    return CurioItemCapability.createProvider(new ICurio() {
-      private Object model;
+	return CurioItemCapability.createProvider(new ICurio() {
+	  private Object model;
 
-      @Override
-      public void curioTick(String identifier, int index, LivingEntity livingEntity) {
+	  @Override
+	  public void curioTick(String identifier, int index, LivingEntity livingEntity) {
 
-        if (!livingEntity.getEntityWorld().isRemote && livingEntity.ticksExisted % 40 == 0) {
-          livingEntity.addPotionEffect(new EffectInstance(Effects.REGENERATION, 80, 0, true, true));
-        }
-      }
+		if (!livingEntity.getEntityWorld().isRemote && livingEntity.ticksExisted % 40 == 0) {
+		  livingEntity.addPotionEffect(new EffectInstance(Effects.REGENERATION, 80, 0, true, true));
+		}
+	  }
 
-      @Override
-      public boolean canRender(String identifier, int index, LivingEntity livingEntity) {
-        return true;
-      }
+	  @Override
+	  public boolean canRender(String identifier, int index, LivingEntity livingEntity) {
+		return true;
+	  }
 
-      @Override
-      public void render(String identifier, int index, MatrixStack matrixStack,
-          IRenderTypeBuffer renderTypeBuffer, int light, LivingEntity livingEntity, float limbSwing,
-          float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw,
-          float headPitch) {
-        ICurio.RenderHelper.translateIfSneaking(matrixStack, livingEntity);
-        ICurio.RenderHelper.rotateIfSneaking(matrixStack, livingEntity);
+	  @Override
+	  public void render(String identifier, int index, MatrixStack matrixStack,
+		  IRenderTypeBuffer renderTypeBuffer, int light, LivingEntity livingEntity, float limbSwing,
+		  float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw,
+		  float headPitch) {
+		ICurio.RenderHelper.translateIfSneaking(matrixStack, livingEntity);
+		ICurio.RenderHelper.rotateIfSneaking(matrixStack, livingEntity);
 
-        if (!(this.model instanceof AmuletModel)) {
-          this.model = new AmuletModel<>();
-        }
-        AmuletModel<?> amuletModel = (AmuletModel<?>) this.model;
-        IVertexBuilder vertexBuilder = ItemRenderer
-            .getBuffer(renderTypeBuffer, amuletModel.getRenderType(AMULET_TEXTURE), false,
-                stack.hasEffect());
-        amuletModel
-            .render(matrixStack, vertexBuilder, light, OverlayTexture.NO_OVERLAY, 1.0F, 1.0F, 1.0F,
-                1.0F);
-      }
-    });
+		if (!(this.model instanceof AmuletModel)) {
+		  this.model = new AmuletModel<>();
+		}
+		AmuletModel<?> amuletModel = (AmuletModel<?>) this.model;
+		IVertexBuilder vertexBuilder = ItemRenderer
+			.getBuffer(renderTypeBuffer, amuletModel.getRenderType(AMULET_TEXTURE), false,
+				stack.hasEffect());
+		amuletModel
+		.render(matrixStack, vertexBuilder, light, OverlayTexture.NO_OVERLAY, 1.0F, 1.0F, 1.0F,
+			1.0F);
+	  }
+	});
   }
 
   @Override
   public boolean hasEffect(ItemStack stack) {
-    return true;
+	return true;
   }
 }

--- a/src/main/java/top/theillusivec4/curios/common/item/CrownItem.java
+++ b/src/main/java/top/theillusivec4/curios/common/item/CrownItem.java
@@ -42,56 +42,56 @@ import top.theillusivec4.curios.common.capability.CurioItemCapability;
 public class CrownItem extends Item {
 
   private static final ResourceLocation CROWN_TEXTURE = new ResourceLocation(Curios.MODID,
-      "textures/entity/crown.png");
+	  "textures/entity/crown.png");
 
   public CrownItem() {
-    super(new Item.Properties().group(ItemGroup.TOOLS).maxStackSize(1).defaultMaxDamage(2000));
-    this.setRegistryName(Curios.MODID, "crown");
+	super(new Item.Properties().group(ItemGroup.TOOLS).maxStackSize(1).defaultMaxDamage(2000));
+	this.setRegistryName(Curios.MODID, "crown");
   }
 
   @Override
   public ICapabilityProvider initCapabilities(ItemStack stack, CompoundNBT unused) {
-    return CurioItemCapability.createProvider(new ICurio() {
-      private Object model;
+	return CurioItemCapability.createProvider(new ICurio() {
+	  private Object model;
 
-      @Override
-      public void curioTick(String identifier, int index, LivingEntity livingEntity) {
+	  @Override
+	  public void curioTick(String identifier, int index, LivingEntity livingEntity, ItemStack stack) {
 
-        if (!livingEntity.getEntityWorld().isRemote && livingEntity.ticksExisted % 20 == 0) {
-          livingEntity
-              .addPotionEffect(new EffectInstance(Effects.NIGHT_VISION, 300, -1, true, true));
-          stack.damageItem(1, livingEntity,
-              damager -> CuriosApi.getCuriosHelper().onBrokenCurio(identifier, index, damager));
-        }
-      }
+		if (!livingEntity.getEntityWorld().isRemote && livingEntity.ticksExisted % 20 == 0) {
+		  livingEntity
+		  .addPotionEffect(new EffectInstance(Effects.NIGHT_VISION, 300, -1, true, true));
+		  stack.damageItem(1, livingEntity,
+			  damager -> CuriosApi.getCuriosHelper().onBrokenCurio(identifier, index, damager));
+		}
+	  }
 
-      @Override
-      public boolean canRender(String identifier, int index, LivingEntity livingEntity) {
-        return true;
-      }
+	  @Override
+	  public boolean canRender(String identifier, int index, LivingEntity livingEntity, ItemStack stack) {
+		return true;
+	  }
 
-      @Override
-      public void render(String identifier, int index, MatrixStack matrixStack,
-          IRenderTypeBuffer renderTypeBuffer, int light, LivingEntity livingEntity, float limbSwing,
-          float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw,
-          float headPitch) {
+	  @Override
+	  public void render(String identifier, int index, MatrixStack matrixStack,
+		  IRenderTypeBuffer renderTypeBuffer, int light, LivingEntity livingEntity, float limbSwing,
+		  float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw,
+		  float headPitch, ItemStack stack) {
 
-        if (!(this.model instanceof CrownModel)) {
-          model = new CrownModel<>();
-        }
-        CrownModel<?> crown = (CrownModel<?>) this.model;
-        ICurio.RenderHelper.followHeadRotations(livingEntity, crown.crown);
-        IVertexBuilder vertexBuilder = ItemRenderer
-            .getBuffer(renderTypeBuffer, crown.getRenderType(CROWN_TEXTURE), false,
-                stack.hasEffect());
-        crown.render(matrixStack, vertexBuilder, light, OverlayTexture.NO_OVERLAY, 1.0F, 1.0F, 1.0F,
-            1.0F);
-      }
-    });
+		if (!(this.model instanceof CrownModel)) {
+		  this.model = new CrownModel<>();
+		}
+		CrownModel<?> crown = (CrownModel<?>) this.model;
+		ICurio.RenderHelper.followHeadRotations(livingEntity, crown.crown);
+		IVertexBuilder vertexBuilder = ItemRenderer
+			.getBuffer(renderTypeBuffer, crown.getRenderType(CROWN_TEXTURE), false,
+				stack.hasEffect());
+		crown.render(matrixStack, vertexBuilder, light, OverlayTexture.NO_OVERLAY, 1.0F, 1.0F, 1.0F,
+			1.0F);
+	  }
+	});
   }
 
   @Override
   public boolean hasEffect(ItemStack stack) {
-    return true;
+	return true;
   }
 }

--- a/src/main/java/top/theillusivec4/curios/common/item/KnucklesItem.java
+++ b/src/main/java/top/theillusivec4/curios/common/item/KnucklesItem.java
@@ -47,62 +47,62 @@ public class KnucklesItem extends Item {
 
   private static final UUID AD_UUID = UUID.fromString("7ce10414-adcc-4bf2-8804-f5dbd39fadaf");
   private static final ResourceLocation KNUCKLES_TEXTURE = new ResourceLocation(Curios.MODID,
-      "textures/entity/knuckles.png");
+	  "textures/entity/knuckles.png");
 
   public KnucklesItem() {
-    super(new Item.Properties().group(ItemGroup.TOOLS).maxStackSize(1));
-    this.setRegistryName(Curios.MODID, "knuckles");
+	super(new Item.Properties().group(ItemGroup.TOOLS).maxStackSize(1));
+	this.setRegistryName(Curios.MODID, "knuckles");
   }
 
   @Override
   public ICapabilityProvider initCapabilities(ItemStack stack, CompoundNBT unused) {
-    return CurioItemCapability.createProvider(new ICurio() {
-      private Object model;
+	return CurioItemCapability.createProvider(new ICurio() {
+	  private Object model;
 
-      @Override
-      public Multimap<Attribute, AttributeModifier> getAttributeModifiers(String identifier) {
-        Multimap<Attribute, AttributeModifier> atts = HashMultimap.create();
+	  @Override
+	  public Multimap<Attribute, AttributeModifier> getAttributeModifiers(String identifier, ItemStack stack) {
+		Multimap<Attribute, AttributeModifier> atts = HashMultimap.create();
 
-        if (CuriosApi.getCuriosHelper().getCurioTags(stack.getItem()).contains(identifier)) {
-          atts.put(Attributes.ATTACK_DAMAGE,
-              new AttributeModifier(AD_UUID, "Attack damage bonus", 4,
-                  AttributeModifier.Operation.ADDITION));
-        }
-        return atts;
-      }
+		if (CuriosApi.getCuriosHelper().getCurioTags(stack.getItem()).contains(identifier)) {
+		  atts.put(Attributes.ATTACK_DAMAGE,
+			  new AttributeModifier(AD_UUID, "Attack damage bonus", 4,
+				  AttributeModifier.Operation.ADDITION));
+		}
+		return atts;
+	  }
 
-      @Override
-      public boolean canRender(String identifier, int index, LivingEntity livingEntity) {
-        return true;
-      }
+	  @Override
+	  public boolean canRender(String identifier, int index, LivingEntity livingEntity, ItemStack stack) {
+		return true;
+	  }
 
-      @Override
-      public void render(String identifier, int index, MatrixStack matrixStack,
-          IRenderTypeBuffer renderTypeBuffer, int light, LivingEntity livingEntity, float limbSwing,
-          float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw,
-          float headPitch) {
+	  @Override
+	  public void render(String identifier, int index, MatrixStack matrixStack,
+		  IRenderTypeBuffer renderTypeBuffer, int light, LivingEntity livingEntity, float limbSwing,
+		  float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw,
+		  float headPitch, ItemStack stack) {
 
-        if (!(this.model instanceof KnucklesModel)) {
-          model = new KnucklesModel();
-        }
+		if (!(this.model instanceof KnucklesModel)) {
+		  this.model = new KnucklesModel();
+		}
 
-        KnucklesModel knuckles = (KnucklesModel) this.model;
-        knuckles.setLivingAnimations(livingEntity, limbSwing, limbSwingAmount, partialTicks);
-        knuckles.setRotationAngles(livingEntity, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw,
-            headPitch);
-        ICurio.RenderHelper.followBodyRotations(livingEntity, knuckles);
-        IVertexBuilder vertexBuilder = ItemRenderer
-            .getBuffer(renderTypeBuffer, knuckles.getRenderType(KNUCKLES_TEXTURE), false,
-                stack.hasEffect());
-        knuckles
-            .render(matrixStack, vertexBuilder, light, OverlayTexture.NO_OVERLAY, 1.0F, 1.0F, 1.0F,
-                1.0F);
-      }
-    });
+		KnucklesModel knuckles = (KnucklesModel) this.model;
+		knuckles.setLivingAnimations(livingEntity, limbSwing, limbSwingAmount, partialTicks);
+		knuckles.setRotationAngles(livingEntity, limbSwing, limbSwingAmount, ageInTicks, netHeadYaw,
+			headPitch);
+		ICurio.RenderHelper.followBodyRotations(livingEntity, knuckles);
+		IVertexBuilder vertexBuilder = ItemRenderer
+			.getBuffer(renderTypeBuffer, knuckles.getRenderType(KNUCKLES_TEXTURE), false,
+				stack.hasEffect());
+		knuckles
+		.render(matrixStack, vertexBuilder, light, OverlayTexture.NO_OVERLAY, 1.0F, 1.0F, 1.0F,
+			1.0F);
+	  }
+	});
   }
 
   @Override
   public boolean hasEffect(ItemStack stack) {
-    return true;
+	return true;
   }
 }

--- a/src/main/java/top/theillusivec4/curios/common/item/RingItem.java
+++ b/src/main/java/top/theillusivec4/curios/common/item/RingItem.java
@@ -48,56 +48,56 @@ public class RingItem extends Item {
   private static final UUID ARMOR_UUID = UUID.fromString("38faf191-bf78-4654-b349-cc1f4f1143bf");
 
   public RingItem() {
-    super(new Item.Properties().group(ItemGroup.TOOLS).maxStackSize(1).defaultMaxDamage(0));
-    this.setRegistryName(Curios.MODID, "ring");
+	super(new Item.Properties().group(ItemGroup.TOOLS).maxStackSize(1).defaultMaxDamage(0));
+	this.setRegistryName(Curios.MODID, "ring");
   }
 
   @Override
   public ICapabilityProvider initCapabilities(ItemStack stack, CompoundNBT unused) {
-    return CurioItemCapability.createProvider(new ICurio() {
+	return CurioItemCapability.createProvider(new ICurio() {
 
-      @Override
-      public void curioTick(String identifier, int index, LivingEntity livingEntity) {
+	  @Override
+	  public void curioTick(String identifier, int index, LivingEntity livingEntity, ItemStack stack) {
 
-        if (!livingEntity.getEntityWorld().isRemote && livingEntity.ticksExisted % 19 == 0) {
-          livingEntity.addPotionEffect(new EffectInstance(Effects.HASTE, 20, 0, true, true));
-        }
-      }
+		if (!livingEntity.getEntityWorld().isRemote && livingEntity.ticksExisted % 19 == 0) {
+		  livingEntity.addPotionEffect(new EffectInstance(Effects.HASTE, 20, 0, true, true));
+		}
+	  }
 
-      @Override
-      public void playRightClickEquipSound(LivingEntity livingEntity) {
-        livingEntity.world.playSound(null, new BlockPos(livingEntity.getPositionVec()),
-            SoundEvents.ITEM_ARMOR_EQUIP_GOLD, SoundCategory.NEUTRAL, 1.0f, 1.0f);
-      }
+	  @Override
+	  public void playRightClickEquipSound(String identifer, LivingEntity livingEntity, ItemStack stack) {
+		livingEntity.world.playSound(null, new BlockPos(livingEntity.getPositionVec()),
+			SoundEvents.ITEM_ARMOR_EQUIP_GOLD, SoundCategory.NEUTRAL, 1.0f, 1.0f);
+	  }
 
-      @Override
-      public Multimap<Attribute, AttributeModifier> getAttributeModifiers(String identifier) {
-        Multimap<Attribute, AttributeModifier> atts = HashMultimap.create();
+	  @Override
+	  public Multimap<Attribute, AttributeModifier> getAttributeModifiers(String identifier, ItemStack stack) {
+		Multimap<Attribute, AttributeModifier> atts = HashMultimap.create();
 
-        if (CuriosApi.getCuriosHelper().getCurioTags(stack.getItem()).contains(identifier)) {
-          atts.put(Attributes.MOVEMENT_SPEED, new AttributeModifier(SPEED_UUID, "Speed bonus", 0.1,
-              AttributeModifier.Operation.MULTIPLY_TOTAL));
-          atts.put(Attributes.ARMOR, new AttributeModifier(ARMOR_UUID, "Armor bonus", 2,
-              AttributeModifier.Operation.ADDITION));
-        }
-        return atts;
-      }
+		if (CuriosApi.getCuriosHelper().getCurioTags(stack.getItem()).contains(identifier)) {
+		  atts.put(Attributes.MOVEMENT_SPEED, new AttributeModifier(SPEED_UUID, "Speed bonus", 0.1,
+			  AttributeModifier.Operation.MULTIPLY_TOTAL));
+		  atts.put(Attributes.ARMOR, new AttributeModifier(ARMOR_UUID, "Armor bonus", 2,
+			  AttributeModifier.Operation.ADDITION));
+		}
+		return atts;
+	  }
 
-      @Nonnull
-      @Override
-      public DropRule getDropRule(LivingEntity livingEntity) {
-        return DropRule.ALWAYS_KEEP;
-      }
+	  @Nonnull
+	  @Override
+	  public DropRule getDropRule(String identifier, LivingEntity livingEntity, ItemStack stack) {
+		return DropRule.ALWAYS_KEEP;
+	  }
 
-      @Override
-      public boolean canRightClickEquip() {
-        return true;
-      }
-    });
+	  @Override
+	  public boolean canRightClickEquip(LivingEntity livingEntity, ItemStack stack) {
+		return true;
+	  }
+	});
   }
 
   @Override
   public boolean hasEffect(ItemStack stack) {
-    return true;
+	return true;
   }
 }


### PR DESCRIPTION
Here I added a bunch of new methods in `ICurio` that allow to access more context about what they are called for. Therefore I moved calls made to this interface by Curios itself to new methods, hopefully didn't forget any.

### The Reasoning

Because with things like `ICurio#canEquip(String, LivingEntity)` or `ICurio#canRightClickEquip()` it's effectively impossible to determine the `ItemStack` handled by the call. Methods like `ICurio#canUnequip(String, LivingEntity)` allow to narrow the list of possible stacks down to one in most cases, but only under the assumption that player doesn't have more than one slot of type where such item can go, or the mod itself doesn't allow to equip more than one instance of the item at once, like Enigmatic Legacy does.

This comes without questioning, but if anything - old methods are marked as `@Deprecated` and are called from new default ones to ensure mods currently using them (which are, like, 95% of mods relying on Curios, including mine) won't instantly break because of those changes. I hope in time until 1.17 comes around most mods will move to overriding new methods and we can remove the deprecated ones, but at least until then we'll have to leave them stuck in the API.

...also gotta mention: I tried to adjust formatter in my IDE to match indendation rules with that in your code, and it seems to overall have worked fine... Except whitespacing still gets done differently somehow, and thus file diff gone wild in some places. I hope this isn't a big concern.