### PR TITLE
Minor fixes for "curio" slot type and a bit more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ build
 # other
 eclipse
 run
+logs
+/Users/
+*.bat

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = co
 
 minecraft {
     mappings channel: 'snapshot', version: "${version_mcp}"
+	accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
 
     runs {
         client {

--- a/src/main/java/top/theillusivec4/curios/api/SlotTypePreset.java
+++ b/src/main/java/top/theillusivec4/curios/api/SlotTypePreset.java
@@ -30,7 +30,7 @@ import top.theillusivec4.curios.api.SlotTypeMessage.Builder;
 public enum SlotTypePreset {
   HEAD("head", 40), NECKLACE("necklace", 60), BACK("back", 80), BODY("body", 100), BRACELET(
       "bracelet", 120), HANDS("hands", 140), RING("ring", 160), BELT("belt", 180), CHARM("charm",
-      200);
+      200), CURIO("curio", 20);
 
   final String id;
   final int priority;

--- a/src/main/java/top/theillusivec4/curios/client/gui/CuriosScreen.java
+++ b/src/main/java/top/theillusivec4/curios/client/gui/CuriosScreen.java
@@ -299,9 +299,8 @@ public class CuriosScreen extends ContainerScreen<CuriosContainer> implements IR
         playerEntity.closeScreen();
       }
       return true;
-    } else {
-      return super.keyPressed(p_keyPressed_1_, p_keyPressed_2_, p_keyPressed_3_);
-    }
+    } else
+	  return super.keyPressed(p_keyPressed_1_, p_keyPressed_2_, p_keyPressed_3_);
   }
 
   @Override
@@ -316,7 +315,7 @@ public class CuriosScreen extends ContainerScreen<CuriosContainer> implements IR
   /**
    * Draws the background layer of this container (behind the item).
    */
-  @SuppressWarnings("deprecation")
+
   @Override
   protected void drawGuiContainerBackgroundLayer(@Nonnull MatrixStack matrixStack,
       float partialTicks, int mouseX, int mouseY) {
@@ -333,7 +332,7 @@ public class CuriosScreen extends ContainerScreen<CuriosContainer> implements IR
         int slotCount = handler.getVisibleSlots();
 
         if (slotCount > 0) {
-          int upperHeight = 7 + slotCount * 18;
+          int upperHeight = 7 + Math.min(slotCount, 9) * 18;
           RenderSystem.color4f(1.0f, 1.0f, 1.0f, 1.0f);
           this.getMinecraft().getTextureManager().bindTexture(CURIO_INVENTORY);
           int xTexOffset = 0;
@@ -378,9 +377,8 @@ public class CuriosScreen extends ContainerScreen<CuriosContainer> implements IR
   protected boolean isPointInRegion(int rectX, int rectY, int rectWidth, int rectHeight,
       double pointX, double pointY) {
 
-    if (this.isRenderButtonHovered) {
-      return false;
-    }
+    if (this.isRenderButtonHovered)
+	  return false;
     return (!this.widthTooNarrow || !this.recipeBookGui.isVisible()) && super
         .isPointInRegion(rectX, rectY, rectWidth, rectHeight, pointX, pointY);
   }
@@ -391,9 +389,9 @@ public class CuriosScreen extends ContainerScreen<CuriosContainer> implements IR
   @Override
   public boolean mouseClicked(double mouseX, double mouseY, int mouseButton) {
 
-    if (this.recipeBookGui.mouseClicked(mouseX, mouseY, mouseButton)) {
-      return true;
-    } else if (this.inScrollBar(mouseX, mouseY)) {
+    if (this.recipeBookGui.mouseClicked(mouseX, mouseY, mouseButton))
+	  return true;
+	else if (this.inScrollBar(mouseX, mouseY)) {
       this.isScrolling = this.needsScrollBars();
       return true;
     }
@@ -411,9 +409,8 @@ public class CuriosScreen extends ContainerScreen<CuriosContainer> implements IR
     if (this.buttonClicked) {
       this.buttonClicked = false;
       return true;
-    } else {
-      return super.mouseReleased(mouseReleased1, mouseReleased3, mouseReleased5);
-    }
+    } else
+	  return super.mouseReleased(mouseReleased1, mouseReleased3, mouseReleased5);
   }
 
   @Override
@@ -427,19 +424,18 @@ public class CuriosScreen extends ContainerScreen<CuriosContainer> implements IR
       currentScroll = MathHelper.clamp(currentScroll, 0.0F, 1.0F);
       this.container.scrollTo(currentScroll);
       return true;
-    } else {
-      return super.mouseDragged(pMouseDragged1, pMouseDragged3, pMouseDragged5, pMouseDragged6,
+    } else
+	  return super.mouseDragged(pMouseDragged1, pMouseDragged3, pMouseDragged5, pMouseDragged6,
           pMouseDragged8);
-    }
   }
 
   @Override
   public boolean mouseScrolled(double pMouseScrolled1, double pMouseScrolled3,
       double pMouseScrolled5) {
 
-    if (!this.needsScrollBars()) {
-      return false;
-    } else {
+    if (!this.needsScrollBars())
+	  return false;
+	else {
       int i = (this.container).curiosHandler.map(ICuriosItemHandler::getVisibleSlots).orElse(1);
       currentScroll = (float) (currentScroll - pMouseScrolled5 / i);
       currentScroll = MathHelper.clamp(currentScroll, 0.0F, 1.0F);
@@ -452,6 +448,7 @@ public class CuriosScreen extends ContainerScreen<CuriosContainer> implements IR
     return this.container.canScroll();
   }
 
+  @Override
   protected boolean hasClickedOutside(double mouseX, double mouseY, int guiLeftIn, int guiTopIn,
       int mouseButton) {
     boolean flag = mouseX < guiLeftIn || mouseY < guiTopIn || mouseX >= guiLeftIn + this.xSize

--- a/src/main/java/top/theillusivec4/curios/client/gui/GuiEventHandler.java
+++ b/src/main/java/top/theillusivec4/curios/client/gui/GuiEventHandler.java
@@ -31,7 +31,6 @@ import net.minecraft.item.ItemGroup;
 import net.minecraft.util.Tuple;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.network.PacketDistributor;
 import org.lwjgl.glfw.GLFW;
 import top.theillusivec4.curios.Curios;
@@ -39,9 +38,6 @@ import top.theillusivec4.curios.common.network.NetworkHandler;
 import top.theillusivec4.curios.common.network.client.CPacketDestroy;
 
 public class GuiEventHandler {
-
-  private static final Method GET_SELECTED_SLOT = ObfuscationReflectionHelper
-      .findMethod(ContainerScreen.class, "func_195360_a", double.class, double.class);
 
   @SubscribeEvent
   public void onInventoryGuiInit(GuiScreenEvent.InitGuiEvent.Post evt) {
@@ -63,14 +59,12 @@ public class GuiEventHandler {
   @SubscribeEvent
   public void onInventoryGuiDrawBackground(GuiScreenEvent.DrawScreenEvent.Pre evt) {
 
-    if (!(evt.getGui() instanceof InventoryScreen)) {
-      return;
-    }
+    if (!(evt.getGui() instanceof InventoryScreen))
+	  return;
     InventoryScreen gui = (InventoryScreen) evt.getGui();
-    ObfuscationReflectionHelper
-        .setPrivateValue(InventoryScreen.class, gui, evt.getMouseX(), "field_147048_u");
-    ObfuscationReflectionHelper
-        .setPrivateValue(InventoryScreen.class, gui, evt.getMouseY(), "field_147047_v");
+
+    gui.oldMouseX = evt.getMouseX();
+    gui.oldMouseY = evt.getMouseY();
   }
 
   @SubscribeEvent
@@ -80,22 +74,20 @@ public class GuiEventHandler {
     boolean isRightShiftDown = InputMappings.isKeyDown(handle, GLFW.GLFW_KEY_RIGHT_SHIFT);
     boolean isShiftDown = isLeftShiftDown || isRightShiftDown;
 
-    if (!(evt.getGui() instanceof CreativeScreen) || !isShiftDown) {
-      return;
-    }
+    if (!(evt.getGui() instanceof CreativeScreen) || !isShiftDown)
+	  return;
 
     CreativeScreen gui = (CreativeScreen) evt.getGui();
 
-    if (gui.getSelectedTabIndex() != ItemGroup.INVENTORY.getIndex()) {
-      return;
-    }
-    Slot destroyItemSlot = ObfuscationReflectionHelper
-        .getPrivateValue(CreativeScreen.class, gui, "field_147064_C");
+    if (gui.getSelectedTabIndex() != ItemGroup.INVENTORY.getIndex())
+	  return;
+    Slot destroyItemSlot = gui.destroyItemSlot;
     Slot slot = null;
 
     try {
-      slot = (Slot) GET_SELECTED_SLOT.invoke(gui, evt.getMouseX(), evt.getMouseY());
+      slot = gui.getSelectedSlot(evt.getMouseX(), evt.getMouseY());
     } catch (Exception err) {
+      // Likely impossibe condition now but whatever
       Curios.LOGGER.error("Could not get selected slot in Creative gui!");
     }
 

--- a/src/main/java/top/theillusivec4/curios/common/event/CuriosEventHandler.java
+++ b/src/main/java/top/theillusivec4/curios/common/event/CuriosEventHandler.java
@@ -59,6 +59,7 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.network.PacketDistributor;
 import top.theillusivec4.curios.api.CuriosApi;
 import top.theillusivec4.curios.api.CuriosCapability;
+import top.theillusivec4.curios.api.SlotTypePreset;
 import top.theillusivec4.curios.api.event.CurioChangeEvent;
 import top.theillusivec4.curios.api.event.CurioDropsEvent;
 import top.theillusivec4.curios.api.event.DropRulesEvent;
@@ -280,9 +281,8 @@ public class CuriosEventHandler {
         for (ICurioStacksHandler stacksHandler : curios.values()) {
 
           if (handleMending(player, stacksHandler.getStacks(), evt) || handleMending(player,
-              stacksHandler.getCosmeticStacks(), evt)) {
-            return;
-          }
+              stacksHandler.getCosmeticStacks(), evt))
+			return;
         }
       });
     }
@@ -308,7 +308,7 @@ public class CuriosEventHandler {
                 Set<String> tags = CuriosApi.getCuriosHelper().getCurioTags(stack.getItem());
                 String id = entry.getKey();
 
-                if (present.isEmpty() && (tags.contains(id) || tags.contains("curio")) && curio
+                if (present.isEmpty() && ((tags.contains(id) || tags.contains(SlotTypePreset.CURIO.getIdentifier())) || (!tags.isEmpty() && id == SlotTypePreset.CURIO.getIdentifier())) && curio
                     .canEquip(id, player)) {
                   stackHandler.setStackInSlot(i, stack.copy());
                   curio.playRightClickEquipSound(player);

--- a/src/main/java/top/theillusivec4/curios/common/integration/jei/CuriosContainerHandler.java
+++ b/src/main/java/top/theillusivec4/curios/common/integration/jei/CuriosContainerHandler.java
@@ -29,30 +29,25 @@ import net.minecraft.client.entity.player.ClientPlayerEntity;
 import net.minecraft.client.gui.recipebook.RecipeBookGui;
 import net.minecraft.client.gui.recipebook.RecipeTabToggleWidget;
 import net.minecraft.client.renderer.Rectangle2d;
-import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import top.theillusivec4.curios.Curios;
 import top.theillusivec4.curios.api.CuriosApi;
 import top.theillusivec4.curios.client.gui.CuriosScreen;
 
 public class CuriosContainerHandler implements IGuiContainerHandler<CuriosScreen> {
 
-  private static final Field RECIPE_TABS = ObfuscationReflectionHelper
-      .findField(RecipeBookGui.class, "field_193018_j");
-
   @Override
   @Nonnull
   public List<Rectangle2d> getGuiExtraAreas(CuriosScreen containerScreen) {
     ClientPlayerEntity player = containerScreen.getMinecraft().player;
 
-    if (player != null) {
-      return CuriosApi.getCuriosHelper().getCuriosHandler(containerScreen.getMinecraft().player)
+    if (player != null)
+	  return CuriosApi.getCuriosHelper().getCuriosHandler(containerScreen.getMinecraft().player)
           .map(handler -> {
             List<Rectangle2d> areas = new ArrayList<>();
             int slotCount = handler.getVisibleSlots();
 
-            if (slotCount <= 0) {
-              return areas;
-            }
+            if (slotCount <= 0)
+			  return areas;
             int width = slotCount > 8 ? 42 : 26;
 
             if (containerScreen.getContainer().hasCosmeticColumn()) {
@@ -68,25 +63,18 @@ public class CuriosContainerHandler implements IGuiContainerHandler<CuriosScreen
               int i = (containerScreen.width - 147) / 2 - (containerScreen.widthTooNarrow ? 0 : 86);
               int j = (containerScreen.height - 166) / 2;
               areas.add(new Rectangle2d(i, j, 147, 166));
-              try {
-                @SuppressWarnings("unchecked") List<RecipeTabToggleWidget> tabs = (List<RecipeTabToggleWidget>) RECIPE_TABS
-                    .get(guiRecipeBook);
 
-                for (RecipeTabToggleWidget tab : tabs) {
-
+                for (RecipeTabToggleWidget tab : guiRecipeBook.recipeTabs) {
                   if (tab.active) {
                     areas.add(new Rectangle2d(tab.x, tab.y, tab.getWidth(), tab.getBlitOffset()));
                   }
                 }
-              } catch (IllegalAccessException e) {
-                Curios.LOGGER.error("Error accessing recipe tabs!");
-              }
+
               return areas;
             }
             return areas;
           }).orElse(Collections.emptyList());
-    } else {
-      return Collections.emptyList();
-    }
+	else
+	  return Collections.emptyList();
   }
 }

--- a/src/main/java/top/theillusivec4/curios/common/inventory/CurioSlot.java
+++ b/src/main/java/top/theillusivec4/curios/common/inventory/CurioSlot.java
@@ -33,6 +33,7 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.items.SlotItemHandler;
 import top.theillusivec4.curios.Curios;
 import top.theillusivec4.curios.api.CuriosApi;
+import top.theillusivec4.curios.api.SlotTypePreset;
 import top.theillusivec4.curios.api.type.inventory.IDynamicStackHandler;
 
 public class CurioSlot extends SlotItemHandler {
@@ -63,18 +64,18 @@ public class CurioSlot extends SlotItemHandler {
 
   @OnlyIn(Dist.CLIENT)
   public String getSlotName() {
-    return I18n.format("curios.identifier." + identifier);
+    return I18n.format("curios.identifier." + this.identifier);
   }
 
   @Override
   public boolean isItemValid(@Nonnull ItemStack stack) {
-    return hasValidTag(CuriosApi.getCuriosHelper().getCurioTags(stack.getItem())) && CuriosApi
-        .getCuriosHelper().getCurio(stack).map(curio -> curio.canEquip(identifier, player))
+    return this.hasValidTag(CuriosApi.getCuriosHelper().getCurioTags(stack.getItem())) && CuriosApi
+        .getCuriosHelper().getCurio(stack).map(curio -> curio.canEquip(this.identifier, this.player))
         .orElse(true) && super.isItemValid(stack);
   }
 
   protected boolean hasValidTag(Set<String> tags) {
-    return this.identifier.equals("curio") || tags.contains(identifier) || tags.contains("curio");
+    return (!tags.isEmpty() && this.identifier.equals(SlotTypePreset.CURIO.getIdentifier())) || tags.contains(this.identifier) || tags.contains(SlotTypePreset.CURIO.getIdentifier());
   }
 
   @Override
@@ -82,7 +83,7 @@ public class CurioSlot extends SlotItemHandler {
     ItemStack stack = this.getStack();
     return (stack.isEmpty() || playerIn.isCreative() || !EnchantmentHelper.hasBindingCurse(stack))
         && CuriosApi.getCuriosHelper().getCurio(stack)
-        .map(curio -> curio.canUnequip(identifier, playerIn)).orElse(true) && super
+        .map(curio -> curio.canUnequip(this.identifier, playerIn)).orElse(true) && super
         .canTakeStack(playerIn);
   }
 }

--- a/src/main/java/top/theillusivec4/curios/common/inventory/container/CuriosContainer.java
+++ b/src/main/java/top/theillusivec4/curios/common/inventory/container/CuriosContainer.java
@@ -51,7 +51,6 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.common.util.LazyOptional;
-import net.minecraftforge.fml.common.ObfuscationReflectionHelper;
 import net.minecraftforge.fml.network.PacketDistributor;
 import top.theillusivec4.curios.api.CuriosApi;
 import top.theillusivec4.curios.api.type.capability.ICuriosItemHandler;
@@ -90,8 +89,8 @@ public class CuriosContainer extends RecipeBookContainer<CraftingInventory> {
   public CuriosContainer(int windowId, PlayerInventory playerInventory) {
     super(CuriosRegistry.CONTAINER_TYPE, windowId);
     this.player = playerInventory.player;
-    this.isLocalWorld = player.world.isRemote;
-    this.curiosHandler = CuriosApi.getCuriosHelper().getCuriosHandler(player);
+    this.isLocalWorld = this.player.world.isRemote;
+    this.curiosHandler = CuriosApi.getCuriosHelper().getCuriosHandler(this.player);
     this.addSlot(
         new CraftingResultSlot(playerInventory.player, this.craftMatrix, this.craftResult, 0, 154,
             28));
@@ -114,7 +113,7 @@ public class CuriosContainer extends RecipeBookContainer<CraftingInventory> {
 
         @Override
         public boolean isItemValid(ItemStack stack) {
-          return stack.canEquip(equipmentslottype, player);
+          return stack.canEquip(equipmentslottype, CuriosContainer.this.player);
         }
 
         @Override
@@ -165,14 +164,14 @@ public class CuriosContainer extends RecipeBookContainer<CraftingInventory> {
         if (stacksHandler.isVisible()) {
 
           for (int i = 0; i < stackHandler.getSlots() && slots < 8; i++) {
-            this.addSlot(new CurioSlot(player, stackHandler, i, identifier, -18, yOffset,
+            this.addSlot(new CurioSlot(this.player, stackHandler, i, identifier, -18, yOffset,
                 stacksHandler.getRenders()));
 
             if (stacksHandler.hasCosmetic()) {
               IDynamicStackHandler cosmeticHandler = stacksHandler.getCosmeticStacks();
               this.cosmeticColumn = true;
               this.addSlot(
-                  new CosmeticCurioSlot(player, cosmeticHandler, i, identifier, -37, yOffset));
+                  new CosmeticCurioSlot(this.player, cosmeticHandler, i, identifier, -37, yOffset));
             }
             yOffset += 18;
             slots++;
@@ -195,11 +194,9 @@ public class CuriosContainer extends RecipeBookContainer<CraftingInventory> {
       int yOffset = 12;
       int index = 0;
       this.inventorySlots.subList(46, this.inventorySlots.size()).clear();
-      NonNullList<ItemStack> inventoryItemStacks = ObfuscationReflectionHelper
-          .getPrivateValue(Container.class, this, "field_75153_a");
 
-      if (inventoryItemStacks != null) {
-        inventoryItemStacks.subList(46, inventoryItemStacks.size()).clear();
+      if (this.inventoryItemStacks != null) {
+        this.inventoryItemStacks.subList(46, this.inventoryItemStacks.size()).clear();
       }
 
       for (String identifier : curioMap.keySet()) {
@@ -211,14 +208,14 @@ public class CuriosContainer extends RecipeBookContainer<CraftingInventory> {
           for (int i = 0; i < stackHandler.getSlots() && slots < 8; i++) {
 
             if (index >= indexIn) {
-              this.addSlot(new CurioSlot(player, stackHandler, i, identifier, -18, yOffset,
+              this.addSlot(new CurioSlot(this.player, stackHandler, i, identifier, -18, yOffset,
                   stacksHandler.getRenders()));
 
               if (stacksHandler.hasCosmetic()) {
                 IDynamicStackHandler cosmeticHandler = stacksHandler.getCosmeticStacks();
                 this.cosmeticColumn = true;
                 this.addSlot(
-                    new CosmeticCurioSlot(player, cosmeticHandler, i, identifier, -37, yOffset));
+                    new CosmeticCurioSlot(this.player, cosmeticHandler, i, identifier, -37, yOffset));
               }
               yOffset += 18;
               slots++;
@@ -230,10 +227,10 @@ public class CuriosContainer extends RecipeBookContainer<CraftingInventory> {
 
       if (!this.isLocalWorld) {
         NetworkHandler.INSTANCE
-            .send(PacketDistributor.PLAYER.with(() -> (ServerPlayerEntity) player),
+            .send(PacketDistributor.PLAYER.with(() -> (ServerPlayerEntity) this.player),
                 new SPacketScroll(this.windowId, indexIn));
       }
-      lastScrollIndex = indexIn;
+      this.lastScrollIndex = indexIn;
     });
   }
 
@@ -241,15 +238,14 @@ public class CuriosContainer extends RecipeBookContainer<CraftingInventory> {
 
     this.curiosHandler.ifPresent(curios -> {
       int k = (curios.getVisibleSlots() - 8);
-      int j = (int) ((double) (pos * (float) k) + 0.5D);
+      int j = (int) (pos * k + 0.5D);
 
       if (j < 0) {
         j = 0;
       }
 
-      if (j == this.lastScrollIndex) {
-        return;
-      }
+      if (j == this.lastScrollIndex)
+		return;
 
       if (this.isLocalWorld) {
         NetworkHandler.INSTANCE
@@ -266,9 +262,8 @@ public class CuriosContainer extends RecipeBookContainer<CraftingInventory> {
       ItemStack stack = ItemStack.EMPTY;
       MinecraftServer server = this.player.world.getServer();
 
-      if (server == null) {
-        return;
-      }
+      if (server == null)
+		return;
 
       Optional<ICraftingRecipe> recipe = server.getRecipeManager()
           .getRecipe(IRecipeType.CRAFTING, this.craftMatrix, this.player.world);
@@ -279,7 +274,7 @@ public class CuriosContainer extends RecipeBookContainer<CraftingInventory> {
           stack = craftingRecipe.getCraftingResult(this.craftMatrix);
         }
       }
-      craftResult.setInventorySlotContents(0, stack);
+      this.craftResult.setInventorySlotContents(0, stack);
       playerMP.connection.sendPacket(new SSetSlotPacket(this.windowId, 0, stack));
     }
   }
@@ -298,9 +293,8 @@ public class CuriosContainer extends RecipeBookContainer<CraftingInventory> {
 
     return this.curiosHandler.map(curios -> {
 
-      if (curios.getVisibleSlots() > 8) {
-        return 1;
-      }
+      if (curios.getVisibleSlots() > 8)
+		return 1;
       return 0;
     }).orElse(0) == 1;
   }
@@ -324,50 +318,41 @@ public class CuriosContainer extends RecipeBookContainer<CraftingInventory> {
       EquipmentSlotType entityequipmentslot = MobEntity.getSlotForItemStack(itemstack);
       if (index == 0) {
 
-        if (!this.mergeItemStack(itemstack1, 9, 45, true)) {
-          return ItemStack.EMPTY;
-        }
+        if (!this.mergeItemStack(itemstack1, 9, 45, true))
+		  return ItemStack.EMPTY;
         slot.onSlotChange(itemstack1, itemstack);
       } else if (index < 5) {
 
-        if (!this.mergeItemStack(itemstack1, 9, 45, false)) {
-          return ItemStack.EMPTY;
-        }
+        if (!this.mergeItemStack(itemstack1, 9, 45, false))
+		  return ItemStack.EMPTY;
       } else if (index < 9) {
 
-        if (!this.mergeItemStack(itemstack1, 9, 45, false)) {
-          return ItemStack.EMPTY;
-        }
+        if (!this.mergeItemStack(itemstack1, 9, 45, false))
+		  return ItemStack.EMPTY;
       } else if (entityequipmentslot.getSlotType() == EquipmentSlotType.Group.ARMOR
           && !this.inventorySlots.get(8 - entityequipmentslot.getIndex()).getHasStack()) {
         int i = 8 - entityequipmentslot.getIndex();
 
-        if (!this.mergeItemStack(itemstack1, i, i + 1, false)) {
-          return ItemStack.EMPTY;
-        }
+        if (!this.mergeItemStack(itemstack1, i, i + 1, false))
+		  return ItemStack.EMPTY;
       } else if (index < 46 && !CuriosApi.getCuriosHelper().getCurioTags(itemstack.getItem())
           .isEmpty()) {
 
-        if (!this.mergeItemStack(itemstack1, 46, this.inventorySlots.size(), false)) {
-          return ItemStack.EMPTY;
-        }
+        if (!this.mergeItemStack(itemstack1, 46, this.inventorySlots.size(), false))
+		  return ItemStack.EMPTY;
       } else if (entityequipmentslot == EquipmentSlotType.OFFHAND && !(this.inventorySlots.get(45))
           .getHasStack()) {
 
-        if (!this.mergeItemStack(itemstack1, 45, 46, false)) {
-          return ItemStack.EMPTY;
-        }
+        if (!this.mergeItemStack(itemstack1, 45, 46, false))
+		  return ItemStack.EMPTY;
       } else if (index < 36) {
-        if (!this.mergeItemStack(itemstack1, 36, 45, false)) {
-          return ItemStack.EMPTY;
-        }
+        if (!this.mergeItemStack(itemstack1, 36, 45, false))
+		  return ItemStack.EMPTY;
       } else if (index < 45) {
-        if (!this.mergeItemStack(itemstack1, 9, 36, false)) {
-          return ItemStack.EMPTY;
-        }
-      } else if (!this.mergeItemStack(itemstack1, 9, 45, false)) {
-        return ItemStack.EMPTY;
-      }
+        if (!this.mergeItemStack(itemstack1, 9, 36, false))
+		  return ItemStack.EMPTY;
+      } else if (!this.mergeItemStack(itemstack1, 9, 45, false))
+		return ItemStack.EMPTY;
 
       if (itemstack1.isEmpty()) {
         slot.putStack(ItemStack.EMPTY);
@@ -375,9 +360,8 @@ public class CuriosContainer extends RecipeBookContainer<CraftingInventory> {
         slot.onSlotChanged();
       }
 
-      if (itemstack1.getCount() == itemstack.getCount()) {
-        return ItemStack.EMPTY;
-      }
+      if (itemstack1.getCount() == itemstack.getCount())
+		return ItemStack.EMPTY;
       ItemStack itemstack2 = slot.onTake(playerIn, itemstack1);
 
       if (index == 0) {

--- a/src/main/java/top/theillusivec4/curios/common/item/KnucklesItem.java
+++ b/src/main/java/top/theillusivec4/curios/common/item/KnucklesItem.java
@@ -59,17 +59,15 @@ public class KnucklesItem extends Item {
     return CurioItemCapability.createProvider(new ICurio() {
       private Object model;
 
-      @Override
-      public Multimap<Attribute, AttributeModifier> getAttributeModifiers(String identifier) {
-        Multimap<Attribute, AttributeModifier> atts = HashMultimap.create();
+	  @Override
+	  public Multimap<Attribute, AttributeModifier> getAttributeModifiers(String identifier) {
+		Multimap<Attribute, AttributeModifier> atts = HashMultimap.create();
 
-        if (CuriosApi.getCuriosHelper().getCurioTags(stack.getItem()).contains(identifier)) {
-          atts.put(Attributes.ATTACK_DAMAGE,
-              new AttributeModifier(AD_UUID, "Attack damage bonus", 4,
-                  AttributeModifier.Operation.ADDITION));
-        }
-        return atts;
-      }
+		atts.put(Attributes.ATTACK_DAMAGE, new AttributeModifier(AD_UUID, Curios.MODID + ":attack_damage_bonus", 4,
+			AttributeModifier.Operation.ADDITION));
+
+		return atts;
+	  }
 
       @Override
       public boolean canRender(String identifier, int index, LivingEntity livingEntity) {
@@ -83,7 +81,7 @@ public class KnucklesItem extends Item {
           float headPitch) {
 
         if (!(this.model instanceof KnucklesModel)) {
-          model = new KnucklesModel();
+          this.model = new KnucklesModel();
         }
 
         KnucklesModel knuckles = (KnucklesModel) this.model;

--- a/src/main/java/top/theillusivec4/curios/common/item/RingItem.java
+++ b/src/main/java/top/theillusivec4/curios/common/item/RingItem.java
@@ -70,18 +70,17 @@ public class RingItem extends Item {
             SoundEvents.ITEM_ARMOR_EQUIP_GOLD, SoundCategory.NEUTRAL, 1.0f, 1.0f);
       }
 
-      @Override
-      public Multimap<Attribute, AttributeModifier> getAttributeModifiers(String identifier) {
-        Multimap<Attribute, AttributeModifier> atts = HashMultimap.create();
+	  @Override
+	  public Multimap<Attribute, AttributeModifier> getAttributeModifiers(String identifier) {
+		Multimap<Attribute, AttributeModifier> atts = HashMultimap.create();
 
-        if (CuriosApi.getCuriosHelper().getCurioTags(stack.getItem()).contains(identifier)) {
-          atts.put(Attributes.MOVEMENT_SPEED, new AttributeModifier(SPEED_UUID, "Speed bonus", 0.1,
-              AttributeModifier.Operation.MULTIPLY_TOTAL));
-          atts.put(Attributes.ARMOR, new AttributeModifier(ARMOR_UUID, "Armor bonus", 2,
-              AttributeModifier.Operation.ADDITION));
-        }
-        return atts;
-      }
+		atts.put(Attributes.MOVEMENT_SPEED, new AttributeModifier(SPEED_UUID, Curios.MODID + ":speed_bonus", 0.1,
+			AttributeModifier.Operation.MULTIPLY_TOTAL));
+		atts.put(Attributes.ARMOR,
+			new AttributeModifier(ARMOR_UUID, Curios.MODID + ":armor_bonus", 2, AttributeModifier.Operation.ADDITION));
+
+		return atts;
+	  }
 
       @Nonnull
       @Override

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,0 +1,8 @@
+public net.minecraft.client.gui.screen.inventory.InventoryScreen field_147048_u #oldMouseX
+public net.minecraft.client.gui.screen.inventory.InventoryScreen field_147047_v #oldMouseY
+
+public net.minecraft.client.gui.screen.inventory.CreativeScreen field_147064_C #destroyItemSlot
+public net.minecraft.client.gui.recipebook.RecipeBookGui field_193018_j #recipeTabs
+public net.minecraft.inventory.container.Container field_75153_a #inventoryItemStacks
+
+public net.minecraft.client.gui.screen.inventory.ContainerScreen func_195360_a(DD)Lnet/minecraft/inventory/container/Slot;  #func_195360_a


### PR DESCRIPTION
Changes here are pretty-self explanatory for the most part, except probably removed checks in attribute getters. I have already provided more extensive commentary on Discord, but long story short for anyone who might accidentally stumble upon this pull request eons later: 

These checks effectively prevent items from providing any attributes when equipped in "curio" slots. I considered whether it's worth any change to how attributes are polled from curios in the first place, but fair enough developers should have a choice to whether or not their items should provide any attributes if they end up in "curio" slots rather than those they are explicitly marked to go into. However, here those ifs only really prevent attribute modifiers from being provided in an instance if curio in question somehow ends up being in invalid slot, because they existed long before the glorification of "curio" slots. As a developer I would expect such cases to be prevented by `canEquip` checks apart from those that are made on the side of Curios itself, but having that check within `getAttributeModifiers` in implementation that is supposed to serve as an example sort of creates the impression you cannot trust anybody with your modifiers, not even the API itself.