### PR TITLE
The IItemCurio thing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ build
 # other
 eclipse
 run
+logs
+/Users/
+*.bat

--- a/src/main/java/top/theillusivec4/curios/Curios.java
+++ b/src/main/java/top/theillusivec4/curios/Curios.java
@@ -83,7 +83,7 @@ public class Curios {
   public static final String MODID = CuriosApi.MODID;
   public static final Logger LOGGER = LogManager.getLogger();
 
-  private static final boolean DEBUG = false;
+  private static final boolean DEBUG = true;
 
   public Curios() {
     final IEventBus eventBus = FMLJavaModLoadingContext.get().getModEventBus();

--- a/src/main/java/top/theillusivec4/curios/Curios.java
+++ b/src/main/java/top/theillusivec4/curios/Curios.java
@@ -83,7 +83,7 @@ public class Curios {
   public static final String MODID = CuriosApi.MODID;
   public static final Logger LOGGER = LogManager.getLogger();
 
-  private static final boolean DEBUG = true;
+  private static final boolean DEBUG = false;
 
   public Curios() {
     final IEventBus eventBus = FMLJavaModLoadingContext.get().getModEventBus();

--- a/src/main/java/top/theillusivec4/curios/api/type/capability/IItemCurio.java
+++ b/src/main/java/top/theillusivec4/curios/api/type/capability/IItemCurio.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright (c) 2018-2020 C4
+ *
+ * This file is part of Curios, a mod made for Minecraft.
+ *
+ * Curios is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Curios is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Curios.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package top.theillusivec4.curios.api.type.capability;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import com.mojang.blaze3d.matrix.MatrixStack;
+import java.util.List;
+import javax.annotation.Nonnull;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.IRenderTypeBuffer;
+import net.minecraft.client.renderer.entity.EntityRenderer;
+import net.minecraft.client.renderer.entity.LivingRenderer;
+import net.minecraft.client.renderer.entity.model.BipedModel;
+import net.minecraft.client.renderer.entity.model.EntityModel;
+import net.minecraft.client.renderer.model.ModelRenderer;
+import net.minecraft.enchantment.EnchantmentHelper;
+import net.minecraft.enchantment.Enchantments;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.ai.attributes.Attribute;
+import net.minecraft.entity.ai.attributes.AttributeModifier;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.particles.ItemParticleData;
+import net.minecraft.particles.ParticleTypes;
+import net.minecraft.util.SoundCategory;
+import net.minecraft.util.SoundEvents;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.vector.Vector3d;
+import net.minecraft.util.math.vector.Vector3f;
+import net.minecraft.util.text.ITextComponent;
+import top.theillusivec4.curios.api.CuriosCapability;
+import top.theillusivec4.curios.api.type.ISlotType;
+import top.theillusivec4.curios.api.type.capability.ICurio.DropRule;
+import net.minecraft.item.Item;
+
+/**
+ * Designed to be directly implemented on {@link Item} objects.<br/><br/>
+ * Curios will automatically create and attach {@link ICurio} capability to any ItemStacks that contain items
+ * implementing this interface, redirecting all calls made on such capability to respective methods here.
+ * @author Extegral
+ */
+
+public interface IItemCurio {
+
+  /**
+   * Default instance of {@link ICurio}, where all calls are redirected by default methods
+   * of this interface to avoid needlessly copying over code from there.
+   */
+
+  public static final ICurio defaultInstance = new ICurio(){};
+
+
+  /**
+   * Called during automatic capability attachment to any ItemStack containing this {@link IItemCurio} instance.
+   * @param stack ItemStack in question
+   * @return true to allow attach {@link ICurio} capability to this ItemStack; false to prevent attachment.
+   */
+
+  default boolean attachCapability(ItemStack stack) {
+	return true;
+  }
+
+  /**
+   * Called every tick on both client and server while the ItemStack is equipped.
+   *
+   * @param identifier   The {@link ISlotType} identifier of the ItemStack's slot
+   * @param index        The index of the slot
+   * @param livingEntity The wearer of the ItemStack
+   * @param stack        The ItemStack in question
+   */
+  default void curioTick(String identifier, int index, LivingEntity livingEntity, ItemStack stack) {
+	defaultInstance.curioTick(identifier, index, livingEntity);
+  }
+
+  /**
+   * Called every tick only on the client while the ItemStack is equipped.
+   *
+   * @param identifier   The {@link ISlotType} identifier of the ItemStack's slot
+   * @param index        The index of the slot
+   * @param livingEntity The wearer of the ItemStack
+   * @param stack        The ItemStack in question
+   */
+  default void curioAnimate(String identifier, int index, LivingEntity livingEntity, ItemStack stack) {
+	defaultInstance.curioAnimate(identifier, index, livingEntity);
+  }
+
+  /**
+   * Called when the ItemStack is equipped into a slot.
+   *
+   * @param identifier   The {@link ISlotType} identifier of the slot being
+   *                     equipped into
+   * @param index        The index of the slot
+   * @param livingEntity The wearer of the ItemStack
+   * @param stack        The ItemStack in question
+   */
+  default void onEquip(String identifier, int index, LivingEntity livingEntity, ItemStack stack) {
+	defaultInstance.onEquip(identifier, index, livingEntity);;
+  }
+
+  /**
+   * Called when the ItemStack is unequipped from a slot.
+   *
+   * @param identifier   The {@link ISlotType} identifier of the slot being
+   *                     unequipped from
+   * @param index        The index of the slot
+   * @param livingEntity The wearer of the ItemStack
+   * @param stack        The ItemStack in question
+   */
+  default void onUnequip(String identifier, int index, LivingEntity livingEntity, ItemStack stack) {
+	defaultInstance.onUnequip(identifier, index, livingEntity);
+  }
+
+  /**
+   * Determines if the ItemStack can be equipped into a slot.
+   *
+   * @param identifier   The {@link ISlotType} identifier of the slot being
+   *                     equipped into
+   * @param livingEntity The wearer of the ItemStack
+   * @param stack        The ItemStack in question
+   * @return True if the ItemStack can be equipped/put in, false if not
+   */
+  default boolean canEquip(String identifier, LivingEntity livingEntity, ItemStack stack) {
+	return defaultInstance.canEquip(identifier, livingEntity);
+  }
+
+  /**
+   * Determines if the ItemStack can be unequipped from a slot.
+   *
+   * @param identifier   The {@link ISlotType} identifier of the slot being
+   *                     unequipped from
+   * @param livingEntity The wearer of the ItemStack
+   * @param stack        The ItemStack in question
+   * @return True if the ItemStack can be unequipped/taken out, false if not
+   */
+  default boolean canUnequip(String identifier, LivingEntity livingEntity, ItemStack stack) {
+	return defaultInstance.canUnequip(identifier, livingEntity);
+  }
+
+  /**
+   * Retrieves a list of tooltips when displaying curio tag information. By
+   * default, this will be a list of each tag identifier, translated and in gold
+   * text, associated with the curio. <br>
+   * If overriding, make sure the user has some indication which tags are
+   * associated with the curio.
+   *
+   * @param tagTooltips A list of {@link ITextComponent} with every curio tag
+   * @return A list of ITextComponent to display as curio tag information
+   */
+  default List<ITextComponent> getTagsTooltip(List<ITextComponent> tagTooltips) {
+	return defaultInstance.getTagsTooltip(tagTooltips);
+  }
+
+  /**
+   * A map of AttributeModifier associated with the ItemStack and the
+   * {@link ISlotType} identifier.
+   *
+   * @param identifier The CurioType identifier for the context
+   * @param stack      The ItemStack in question
+   * @return A map of attribute modifiers to apply
+   */
+  default Multimap<Attribute, AttributeModifier> getAttributeModifiers(String identifier, ItemStack stack) {
+	return defaultInstance.getAttributeModifiers(identifier);
+  }
+
+  /**
+   * Plays a sound server-side when a curio is equipped from right-clicking the
+   * ItemStack in hand. This can be overridden to play nothing, but it is advised
+   * to always play something as an auditory feedback for players.
+   *
+   * @param identifier Identifier of slot into which stack is equipped
+   * @param stack      The ItemStack in question
+   */
+  default void playRightClickEquipSound(LivingEntity livingEntity, ItemStack stack) {
+	defaultInstance.playRightClickEquipSound(livingEntity);
+  }
+
+  /**
+   * Determines if the ItemStack can be automatically equipped into the first
+   * available slot when right-clicked.
+   *
+   * @param stack The ItemStack in question
+   * @return True to enable right-clicking auto-equip, false to disable
+   */
+  default boolean canRightClickEquip(ItemStack stack) {
+	return defaultInstance.canRightClickEquip();
+  }
+
+  /**
+   * Called when rendering break animations and sounds client-side when a worn
+   * curio item is broken.
+   *
+   * @param stack        The ItemStack that was broken
+   * @param livingEntity The entity that broke the curio
+   */
+  default void curioBreak(ItemStack stack, LivingEntity livingEntity) {
+	defaultInstance.curioBreak(stack, livingEntity);
+  }
+
+  /**
+   * Compares the current ItemStack and the previous ItemStack in the slot to
+   * detect any changes and returns true if the change should be synced to all
+   * tracking clients. Note that this check occurs every tick so implementations
+   * need to code their own timers for other intervals.
+   *
+   * @param identifier   The identifier of the {@link ISlotType} of the slot
+   * @param index        The index of the slot
+   * @param livingEntity The LivingEntity that is wearing the ItemStack
+   * @return True to sync the ItemStack change to all tracking clients, false to
+   *         do nothing
+   */
+  default boolean canSync(String identifier, int index, LivingEntity livingEntity) {
+	return defaultInstance.canSync(identifier, index, livingEntity);
+  }
+
+  /**
+   * Gets a tag that is used to sync extra curio data from the server to the
+   * client. Only used when {@link IItemCurio#canSync(String, int, LivingEntity)}
+   * returns true.
+   *
+   * @return Data to be sent to the client
+   */
+  @Nonnull
+  default CompoundNBT writeSyncData() {
+	return defaultInstance.writeSyncData();
+  }
+
+  /**
+   * Used client-side to read data tags created by
+   * {@link IItemCurio#writeSyncData()} received from the server.
+   *
+   * @param compound Data received from the server
+   */
+  default void readSyncData(CompoundNBT compound) {
+	defaultInstance.readSyncData(compound);
+  }
+
+  /**
+   * Determines if the ItemStack should drop on death and persist through respawn.
+   * This will persist the ItemStack in the curio slot to the respawned player if
+   * applicable.
+   *
+   * @param identifier Identifier of slot into which stack is equipped
+   * @param stack      The ItemStack in question
+   * @return {@link DropRule}
+   */
+  @Nonnull
+  default DropRule getDropRule(LivingEntity livingEntity, ItemStack stack) {
+	return defaultInstance.getDropRule(livingEntity);
+  }
+
+  /**
+   * Determines whether or not Curios will automatically add tooltip listing
+   * attribute modifiers that are returned by
+   * {@link IItemCurio#getAttributeModifiers(String)}.
+   *
+   * @param identifier The identifier of the {@link ISlotType} of the slot
+   * @param stack      The ItemStack in question
+   * @return True to show attributes tooltip, false to disable
+   */
+  default boolean showAttributesTooltip(String identifier, ItemStack stack) {
+	return defaultInstance.showAttributesTooltip(identifier);
+  }
+
+  /**
+   * Allows to set the amount of bonus Fortune levels that are provided by curio.
+   * Default implementation returns level of Fortune enchantment on ItemStack.
+   *
+   * @param identifier   The identifier of the {@link ISlotType} of the slot
+   * @param curio        ItemStack that is checked
+   * @param index        The index of the slot
+   * @param livingEntity The LivingEntity that is wearing the ItemStack
+   * @return Amount of additional Fortune levels that will be applied when mining
+   */
+  default int getFortuneBonus(String identifier, LivingEntity livingEntity, ItemStack curio, int index) {
+	return defaultInstance.getFortuneBonus(identifier, livingEntity, curio, index);
+  }
+
+  /**
+   * Allows to set the amount of bonus Looting levels that are provided by curio.
+   * Default implementation returns level of Looting enchantment on ItemStack.
+   *
+   * @param identifier   The identifier of the {@link ISlotType} of the slot
+   * @param curio        ItemStack that is checked
+   * @param index        The index of the slot
+   * @param livingEntity The LivingEntity that is wearing the ItemStack
+   * @return Amount of additional Looting levels that will be applied in
+   *         LootingLevelEvent
+   */
+  default int getLootingBonus(String identifier, LivingEntity livingEntity, ItemStack curio, int index) {
+	return defaultInstance.getLootingBonus(identifier, livingEntity, curio, index);
+  }
+
+  /**
+   * Determines if the ItemStack has rendering.
+   *
+   * @param identifier   The identifier of the {@link ISlotType} of the slot
+   * @param index        The index of the slot
+   * @param livingEntity The LivingEntity that is wearing the ItemStack
+   * @param stack        The ItemStack in question
+   * @return True if the ItemStack has rendering, false if it does not
+   */
+  default boolean canRender(String identifier, int index, LivingEntity livingEntity, ItemStack stack) {
+	return defaultInstance.canRender(identifier, index, livingEntity);
+  }
+
+  /**
+   * Performs rendering of the ItemStack if
+   * {@link IItemCurio#canRender(String, int, LivingEntity)} returns true. Note
+   * that vertical sneaking translations are automatically applied before this
+   * rendering method is called.
+   *
+   * @param identifier   The identifier of the {@link ISlotType} of the slot
+   * @param livingEntity The LivingEntity that is wearing the ItemStack
+   * @param stack        The ItemStack in question
+   */
+  default void render(String identifier, int index, MatrixStack matrixStack, IRenderTypeBuffer renderTypeBuffer,
+	  int light, LivingEntity livingEntity, float limbSwing, float limbSwingAmount, float partialTicks,
+	  float ageInTicks, float netHeadYaw, float headPitch, ItemStack stack) {
+
+	defaultInstance.render(identifier, index, matrixStack, renderTypeBuffer, light, livingEntity, limbSwing,
+		limbSwingAmount, partialTicks, ageInTicks, netHeadYaw, headPitch);
+  }
+
+}

--- a/src/main/java/top/theillusivec4/curios/common/capability/CurioItemCapability.java
+++ b/src/main/java/top/theillusivec4/curios/common/capability/CurioItemCapability.java
@@ -19,6 +19,8 @@
 
 package top.theillusivec4.curios.common.capability;
 
+import java.util.concurrent.Callable;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import net.minecraft.nbt.CompoundNBT;
@@ -66,7 +68,7 @@ public class CurioItemCapability {
     @Nonnull
     @Override
     public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap, @Nullable Direction side) {
-      return CuriosCapability.ITEM.orEmpty(cap, capability);
+      return CuriosCapability.ITEM.orEmpty(cap, this.capability);
     }
   }
 }

--- a/src/main/java/top/theillusivec4/curios/common/capability/ItemizedCurioCapability.java
+++ b/src/main/java/top/theillusivec4/curios/common/capability/ItemizedCurioCapability.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2018-2020 C4
+ *
+ * This file is part of Curios, a mod made for Minecraft.
+ *
+ * Curios is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Curios is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with Curios.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package top.theillusivec4.curios.common.capability;
+
+import java.util.List;
+
+import com.google.common.collect.Multimap;
+import com.mojang.blaze3d.matrix.MatrixStack;
+
+import net.minecraft.client.renderer.IRenderTypeBuffer;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.ai.attributes.Attribute;
+import net.minecraft.entity.ai.attributes.AttributeModifier;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.CompoundNBT;
+import net.minecraft.util.text.ITextComponent;
+import top.theillusivec4.curios.api.type.capability.ICurio;
+import top.theillusivec4.curios.api.type.capability.IItemCurio;
+
+public class ItemizedCurioCapability implements ICurio {
+	private final ItemStack stackInstance;
+	private final IItemCurio curioItem;
+
+	public ItemizedCurioCapability(IItemCurio curio, ItemStack stack) {
+		this.curioItem = curio;
+		this.stackInstance = stack;
+	}
+
+	@Override
+	public boolean canEquip(String identifier, LivingEntity livingEntity) {
+		return this.curioItem.canEquip(identifier, livingEntity, this.stackInstance);
+	}
+
+	@Override
+	public boolean canRender(String identifier, int index, LivingEntity livingEntity) {
+		return this.curioItem.canRender(identifier, index, livingEntity, this.stackInstance);
+	}
+
+	@Override
+	public boolean canRightClickEquip() {
+		// Entity unknown
+		return this.curioItem.canRightClickEquip(this.stackInstance);
+	}
+
+	@Override
+	public boolean canSync(String identifier, int index, LivingEntity livingEntity) {
+		return this.curioItem.canSync(identifier, index, livingEntity);
+	}
+
+	@Override
+	public boolean canUnequip(String identifier, LivingEntity livingEntity) {
+		return this.curioItem.canUnequip(identifier, livingEntity, this.stackInstance);
+	}
+
+	@Override
+	public void curioAnimate(String identifier, int index, LivingEntity livingEntity) {
+		this.curioItem.curioAnimate(identifier, index, livingEntity, this.stackInstance);
+	}
+
+	@Override
+	public void curioBreak(ItemStack stack, LivingEntity livingEntity) {
+		this.curioItem.curioBreak(stack, livingEntity);
+	}
+
+	@Override
+	public Multimap<Attribute, AttributeModifier> getAttributeModifiers(String identifier) {
+		return this.curioItem.getAttributeModifiers(identifier, this.stackInstance);
+	}
+
+	@Override
+	public void curioTick(String identifier, int index, LivingEntity livingEntity) {
+		this.curioItem.curioTick(identifier, index, livingEntity, this.stackInstance);
+	}
+
+	@Override
+	public DropRule getDropRule(LivingEntity livingEntity) {
+		return this.curioItem.getDropRule(livingEntity, this.stackInstance);
+	}
+
+	@Override
+	public int getFortuneBonus(String identifier, LivingEntity livingEntity, ItemStack curioStack, int index) {
+		return this.curioItem.getFortuneBonus(identifier, livingEntity, curioStack, index);
+	}
+
+	@Override
+	public int getLootingBonus(String identifier, LivingEntity livingEntity, ItemStack curioStack, int index) {
+		return this.curioItem.getLootingBonus(identifier, livingEntity, curioStack, index);
+	}
+
+	@Override
+	public List<ITextComponent> getTagsTooltip(List<ITextComponent> tagTooltips) {
+		return this.curioItem.getTagsTooltip(tagTooltips);
+	}
+
+	@Override
+	public void onEquip(String identifier, int index, LivingEntity livingEntity) {
+		this.curioItem.onEquip(identifier, index, livingEntity, this.stackInstance);
+	}
+
+	@Override
+	public void onUnequip(String identifier, int index, LivingEntity livingEntity) {
+		this.curioItem.onUnequip(identifier, index, livingEntity, this.stackInstance);
+	}
+
+	@Override
+	public void playRightClickEquipSound(LivingEntity livingEntity) {
+		this.curioItem.playRightClickEquipSound(livingEntity, this.stackInstance);
+	}
+
+	@Override
+	public void readSyncData(CompoundNBT compound) {
+		this.curioItem.readSyncData(compound);
+	}
+
+	@Override
+	public void render(String identifier, int index, MatrixStack matrixStack, IRenderTypeBuffer renderTypeBuffer,
+			int light, LivingEntity livingEntity, float limbSwing, float limbSwingAmount, float partialTicks,
+			float ageInTicks, float netHeadYaw, float headPitch) {
+
+		this.curioItem.render(identifier, index, matrixStack, renderTypeBuffer, light, livingEntity, limbSwing,
+				limbSwingAmount, partialTicks, ageInTicks, netHeadYaw, headPitch, this.stackInstance);
+	}
+
+	@Override
+	public boolean showAttributesTooltip(String identifier) {
+		return this.curioItem.showAttributesTooltip(identifier, this.stackInstance);
+	}
+
+	@Override
+	public CompoundNBT writeSyncData() {
+		return this.curioItem.writeSyncData();
+	}
+
+}

--- a/src/main/java/top/theillusivec4/curios/common/event/CuriosEventHandler.java
+++ b/src/main/java/top/theillusivec4/curios/common/event/CuriosEventHandler.java
@@ -27,6 +27,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.enchantment.Enchantments;
 import net.minecraft.entity.Entity;
@@ -38,12 +42,15 @@ import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.ActionResultType;
+import net.minecraft.util.Direction;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Tuple;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.GameRules;
 import net.minecraft.world.server.ServerWorld;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.event.AttachCapabilitiesEvent;
 import net.minecraftforge.event.entity.EntityJoinWorldEvent;
@@ -66,9 +73,11 @@ import top.theillusivec4.curios.api.type.ISlotType;
 import top.theillusivec4.curios.api.type.capability.ICurio;
 import top.theillusivec4.curios.api.type.capability.ICurio.DropRule;
 import top.theillusivec4.curios.api.type.capability.ICuriosItemHandler;
+import top.theillusivec4.curios.api.type.capability.IItemCurio;
 import top.theillusivec4.curios.api.type.inventory.ICurioStacksHandler;
 import top.theillusivec4.curios.api.type.inventory.IDynamicStackHandler;
 import top.theillusivec4.curios.common.capability.CurioInventoryCapability;
+import top.theillusivec4.curios.common.capability.ItemizedCurioCapability;
 import top.theillusivec4.curios.common.network.NetworkHandler;
 import top.theillusivec4.curios.common.network.server.SPacketSetIcons;
 import top.theillusivec4.curios.common.network.server.sync.SPacketSyncCurios;
@@ -167,6 +176,34 @@ public class CuriosEventHandler {
       evt.addCapability(CuriosCapability.ID_INVENTORY,
           CurioInventoryCapability.createProvider((PlayerEntity) evt.getObject()));
     }
+  }
+
+  /**
+   * Handler for registering item's capabilities implemented through IItemCurio interface.
+   */
+
+  @SubscribeEvent
+  public void attachStackCabilities(AttachCapabilitiesEvent<ItemStack> evt) {
+	ItemStack stack = evt.getObject();
+
+	if (stack.getItem() instanceof IItemCurio) {
+	  IItemCurio itemCurio = (IItemCurio)stack.getItem();
+
+	  if (itemCurio.attachCapability(stack)) {
+		ItemizedCurioCapability itemizedCapability = new ItemizedCurioCapability(itemCurio, stack);
+
+		evt.addCapability(CuriosCapability.ID_ITEM, new ICapabilityProvider() {
+		LazyOptional<ICurio> curio = LazyOptional.of(() -> itemizedCapability);
+
+		@Nonnull
+		@Override
+		public <T> LazyOptional<T> getCapability(@Nonnull Capability<T> cap, @Nullable Direction side) {
+		  return CuriosCapability.ITEM.orEmpty(cap, this.curio);
+		}
+		});
+	  }
+	}
+
   }
 
   @SubscribeEvent
@@ -280,9 +317,8 @@ public class CuriosEventHandler {
         for (ICurioStacksHandler stacksHandler : curios.values()) {
 
           if (handleMending(player, stacksHandler.getStacks(), evt) || handleMending(player,
-              stacksHandler.getCosmeticStacks(), evt)) {
-            return;
-          }
+              stacksHandler.getCosmeticStacks(), evt))
+			return;
         }
       });
     }

--- a/src/main/java/top/theillusivec4/curios/common/item/AmuletItem.java
+++ b/src/main/java/top/theillusivec4/curios/common/item/AmuletItem.java
@@ -35,61 +35,56 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import top.theillusivec4.curios.Curios;
 import top.theillusivec4.curios.api.type.capability.ICurio;
+import top.theillusivec4.curios.api.type.capability.IItemCurio;
 import top.theillusivec4.curios.client.render.model.AmuletModel;
 import top.theillusivec4.curios.common.capability.CurioItemCapability;
 
-public class AmuletItem extends Item {
-
+public class AmuletItem extends Item implements IItemCurio {
   private static final ResourceLocation AMULET_TEXTURE = new ResourceLocation(Curios.MODID,
-      "textures/entity/amulet.png");
+	  "textures/entity/amulet.png");
+  private Object model;
 
   public AmuletItem() {
-    super(new Item.Properties().group(ItemGroup.TOOLS).maxStackSize(1).defaultMaxDamage(0));
-    this.setRegistryName(Curios.MODID, "amulet");
+	super(new Item.Properties().group(ItemGroup.TOOLS).maxStackSize(1).defaultMaxDamage(0));
+	this.setRegistryName(Curios.MODID, "amulet");
   }
 
   @Override
-  public ICapabilityProvider initCapabilities(ItemStack stack, CompoundNBT unused) {
-    return CurioItemCapability.createProvider(new ICurio() {
-      private Object model;
+  public void curioTick(String identifier, int index, LivingEntity living, ItemStack stack) {
+	if (!living.getEntityWorld().isRemote && living.ticksExisted % 40 == 0) {
+	  living.addPotionEffect(new EffectInstance(Effects.REGENERATION, 80, 0, true, true));
+	}
+  }
 
-      @Override
-      public void curioTick(String identifier, int index, LivingEntity livingEntity) {
+  @Override
+  public boolean canRender(String identifier, int index, LivingEntity living, ItemStack stack) {
+	return true;
+  }
 
-        if (!livingEntity.getEntityWorld().isRemote && livingEntity.ticksExisted % 40 == 0) {
-          livingEntity.addPotionEffect(new EffectInstance(Effects.REGENERATION, 80, 0, true, true));
-        }
-      }
+  @Override
+  public void render(String identifier, int index, MatrixStack matrixStack,
+      IRenderTypeBuffer renderTypeBuffer, int light, LivingEntity living, float limbSwing,
+      float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw,
+      float headPitch, ItemStack stack) {
+    ICurio.RenderHelper.translateIfSneaking(matrixStack, living);
+    ICurio.RenderHelper.rotateIfSneaking(matrixStack, living);
 
-      @Override
-      public boolean canRender(String identifier, int index, LivingEntity livingEntity) {
-        return true;
-      }
+    if (!(this.model instanceof AmuletModel)) {
+      this.model = new AmuletModel<>();
+    }
 
-      @Override
-      public void render(String identifier, int index, MatrixStack matrixStack,
-          IRenderTypeBuffer renderTypeBuffer, int light, LivingEntity livingEntity, float limbSwing,
-          float limbSwingAmount, float partialTicks, float ageInTicks, float netHeadYaw,
-          float headPitch) {
-        ICurio.RenderHelper.translateIfSneaking(matrixStack, livingEntity);
-        ICurio.RenderHelper.rotateIfSneaking(matrixStack, livingEntity);
-
-        if (!(this.model instanceof AmuletModel)) {
-          this.model = new AmuletModel<>();
-        }
-        AmuletModel<?> amuletModel = (AmuletModel<?>) this.model;
-        IVertexBuilder vertexBuilder = ItemRenderer
-            .getBuffer(renderTypeBuffer, amuletModel.getRenderType(AMULET_TEXTURE), false,
-                stack.hasEffect());
-        amuletModel
-            .render(matrixStack, vertexBuilder, light, OverlayTexture.NO_OVERLAY, 1.0F, 1.0F, 1.0F,
-                1.0F);
-      }
-    });
+    AmuletModel<?> amuletModel = (AmuletModel<?>) this.model;
+    IVertexBuilder vertexBuilder = ItemRenderer
+        .getBuffer(renderTypeBuffer, amuletModel.getRenderType(AMULET_TEXTURE), false,
+            stack.hasEffect());
+    amuletModel
+        .render(matrixStack, vertexBuilder, light, OverlayTexture.NO_OVERLAY, 1.0F, 1.0F, 1.0F,
+            1.0F);
   }
 
   @Override
   public boolean hasEffect(ItemStack stack) {
-    return true;
+	return true;
   }
+
 }


### PR DESCRIPTION
Once again changes brought in this request explain themselves much better than I could just by looking through them, but brief description:

The `IItemCurio` interface is designed to be directly implemented on Items, in an instance where all the flexibility of default capability implementation may not required. This allows to get rid of excessive subclassing and spares you the burden of having to initialize this capability yourself for every item, since Curios will automatically instantiate and initialize capabilities for all `ItemStack`s that contain instances of `IItemCurio` within, redirecting calls made on `ICurio` to respective methods in `IItemCurio`. Most methods in `IItemCurio` only differ from those in `ICurio` by the addition of associated `ItemStack` object, which is retained from attachment event itself.

Also I have decided it's worth to use this interface somewhere among items of Curios, to provide an example on how it can be implemented on item, so I changed `AmuletItem` for that purpose.