### PR TITLE
Add support for the Catalogue mod.

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -12,6 +12,7 @@ authors="${mod_author}"
 description='''
 ${mod_description}
 '''
+itemIcon="curios:ring"
 [[dependencies.curios]]
     modId="forge"
     mandatory=true


### PR DESCRIPTION
The [Catalogue mod](https://www.curseforge.com/minecraft/mc-mods/catalogue) is a visual replacement for Forge's mod list. This PR provides the meta info to set the icon for Curios to the example ring item, by default it's just a grass block.

![image](https://user-images.githubusercontent.com/2250798/118300666-6f988b80-b49f-11eb-98c1-33c382bdea5f.png)
