### PR TITLE
Fix fortune bonus parsing error

### DIFF
--- a/src/main/resources/data/curios/loot_modifiers/fortune_bonus.json
+++ b/src/main/resources/data/curios/loot_modifiers/fortune_bonus.json
@@ -1,4 +1,4 @@
 {
   "conditions": [],
-  "function": "curios:fortune_bonus"
+  "type": "curios:fortune_bonus"
 }


### PR DESCRIPTION
Running Curios 1.18-5.0.2.1 in my dev environment gave me this error:
```
[23:21:51] [Render thread/ERROR]: Couldn't parse loot modifier curios:fortune_bonus
com.google.gson.JsonSyntaxException: Missing type, expected to find a string
	at net.minecraft.util.GsonHelper.getAsString(GsonHelper.java:85)
	at net.minecraftforge.common.loot.LootModifierManager.deserializeModifier(LootModifierManager.java:131)
	...
```
Changing `function` to `type` should fix that :)