### PR TITLE
[1.19.3] Allow Curios items to let players walk on powder snow.

### DIFF
--- a/src/main/java/top/theillusivec4/curios/api/type/capability/ICurio.java
+++ b/src/main/java/top/theillusivec4/curios/api/type/capability/ICurio.java
@@ -283,6 +283,17 @@ public interface ICurio {
   }
 
   /**
+   * Determines whether wearing the curio will allow the user to walk on powder snow, in the same manner as
+   * wearing leather boots in vanilla.
+   *
+   * @param slotContext Context about the slot that the ItemStack is in
+   * @return True if the user can walk on powder snow, false otherwise
+   */
+  default boolean canWalkOnPowderedSnow(SlotContext slotContext) {
+    return this.getStack().canWalkOnPowderedSnow(slotContext.entity());
+  }
+
+  /**
    * Determines whether wearing the curio masks the user's eyes against Enderman, in the same manner
    * as wearing a pumpkin in vanilla.
    *

--- a/src/main/java/top/theillusivec4/curios/mixin/CuriosMixinHooks.java
+++ b/src/main/java/top/theillusivec4/curios/mixin/CuriosMixinHooks.java
@@ -70,6 +70,30 @@ public class CuriosMixinHooks {
     }).orElse(false);
   }
 
+  public static boolean canWalkOnPowderSnow(LivingEntity livingEntity) {
+    return CuriosApi.getCuriosHelper().getCuriosHandler(livingEntity).map(handler -> {
+
+      for (Map.Entry<String, ICurioStacksHandler> entry : handler.getCurios().entrySet()) {
+        IDynamicStackHandler stacks = entry.getValue().getStacks();
+
+        for (int i = 0; i < stacks.getSlots(); i++) {
+          final int index = i;
+          NonNullList<Boolean> renderStates = entry.getValue().getRenders();
+          boolean canWalk =
+                  CuriosApi.getCuriosHelper().getCurio(stacks.getStackInSlot(i)).map(curio -> curio
+                                  .canWalkOnPowderedSnow(new SlotContext(entry.getKey(), livingEntity, index, false,
+                                          renderStates.size() > index && renderStates.get(index))))
+                          .orElse(false);
+
+          if (canWalk) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }).orElse(false);
+  }
+
   public static int getFortuneLevel(Player player) {
     return CuriosApi.getCuriosHelper().getCuriosHandler(player)
         .map(handler -> handler.getFortuneLevel(null)).orElse(0);

--- a/src/main/java/top/theillusivec4/curios/mixin/core/MixinPowderSnowBlock.java
+++ b/src/main/java/top/theillusivec4/curios/mixin/core/MixinPowderSnowBlock.java
@@ -1,0 +1,23 @@
+package top.theillusivec4.curios.mixin.core;
+
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.block.PowderSnowBlock;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import top.theillusivec4.curios.mixin.CuriosMixinHooks;
+
+@Mixin(PowderSnowBlock.class)
+public class MixinPowderSnowBlock {
+
+  @Inject(at = @At("RETURN"), method = "canEntityWalkOnPowderSnow", cancellable = true)
+  private static void curios$canEntityWalkOnPowderSnow(Entity entity,
+                                                       CallbackInfoReturnable<Boolean> cir) {
+
+    if (entity instanceof LivingEntity livingEntity && CuriosMixinHooks.canWalkOnPowderSnow(livingEntity)) {
+      cir.setReturnValue(true);
+    }
+  }
+}

--- a/src/main/resources/curios.mixins.json
+++ b/src/main/resources/curios.mixins.json
@@ -7,6 +7,7 @@
     "MixinApplyBonusCount",
     "MixinLivingEntity",
     "MixinPiglinAi",
+    "MixinPowderSnowBlock",
     "MixinShearsItem"
   ],
   "minVersion": "0.8"


### PR DESCRIPTION
Makes the `canWalkOnPowderedSnow` method work with Curios items using hooks similar to Piglin neutralization.