### PR TITLE
[1.19.3; Fix] Equip sounds now work with Curios slots and the Curios menu

### DIFF
--- a/src/main/java/top/theillusivec4/curios/common/inventory/CurioSlot.java
+++ b/src/main/java/top/theillusivec4/curios/common/inventory/CurioSlot.java
@@ -38,7 +38,6 @@ import top.theillusivec4.curios.api.SlotContext;
 import top.theillusivec4.curios.api.event.CurioEquipEvent;
 import top.theillusivec4.curios.api.event.CurioUnequipEvent;
 import top.theillusivec4.curios.api.type.inventory.IDynamicStackHandler;
-import top.theillusivec4.curios.common.inventory.container.CuriosContainer;
 
 public class CurioSlot extends SlotItemHandler {
 

--- a/src/main/java/top/theillusivec4/curios/common/inventory/CurioSlot.java
+++ b/src/main/java/top/theillusivec4/curios/common/inventory/CurioSlot.java
@@ -38,6 +38,7 @@ import top.theillusivec4.curios.api.SlotContext;
 import top.theillusivec4.curios.api.event.CurioEquipEvent;
 import top.theillusivec4.curios.api.event.CurioUnequipEvent;
 import top.theillusivec4.curios.api.type.inventory.IDynamicStackHandler;
+import top.theillusivec4.curios.common.inventory.container.CuriosContainer;
 
 public class CurioSlot extends SlotItemHandler {
 
@@ -73,6 +74,12 @@ public class CurioSlot extends SlotItemHandler {
   @OnlyIn(Dist.CLIENT)
   public String getSlotName() {
     return I18n.get("curios.identifier." + this.identifier);
+  }
+
+  @Override
+  public void set(@Nonnull ItemStack stack) {
+    super.set(stack);
+    CuriosApi.getCuriosHelper().getCurio(stack).ifPresent(curio -> curio.onEquipFromUse(slotContext));
   }
 
   @Override

--- a/src/main/java/top/theillusivec4/curios/common/inventory/container/CuriosContainer.java
+++ b/src/main/java/top/theillusivec4/curios/common/inventory/container/CuriosContainer.java
@@ -108,6 +108,12 @@ public class CuriosContainer extends InventoryMenu {
     for (int k = 0; k < 4; ++k) {
       final EquipmentSlot equipmentslottype = VALID_EQUIPMENT_SLOTS[k];
       this.addSlot(new Slot(playerInventory, 36 + (3 - k), 8, 8 + k * 18) {
+        @Override
+        public void set(@Nonnull ItemStack stack) {
+          ItemStack itemstack = this.getItem();
+          super.set(stack);
+          CuriosContainer.this.player.onEquipItem(equipmentslottype, itemstack, stack);
+        }
 
         @Override
         public int getMaxStackSize() {


### PR DESCRIPTION
This PR fixes some bugs where equip sounds were not working in two instances with Curios. The first was that Vanilla armor equipping using shift + right-click when in the Curios menu was not playing the armor items' equip sounds. The second was that Curios slots in general did not seem to have support for playing their equip sounds when using shift + right-click when in a menu with the slots.