### PR TITLE
Fix block-breaking crash for NeoForge

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,8 +23,8 @@ forge_version=50.0.4
 forge_version_range=[50,)
 
 # NeoForge
-neoforge_version=20.6.78-beta
-neoforge_version_range=[20.6.78-beta,)
+neoforge_version=20.6.113-beta
+neoforge_version_range=[20.6.113-beta,)
 
 # Compatibility
 jei_version=17.3.0.49

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'multiloader-loader'
-    id 'net.neoforged.gradle.userdev' version '7.0.107'
+    id 'net.neoforged.gradle.userdev' version '7.0.142'
     id 'com.modrinth.minotaur' version '2.+'
     id 'net.darkhax.curseforgegradle' version '1.+'
 }


### PR DESCRIPTION
Fixes #419, since `BlockEvent.BreakEvent` no longer has the `.setExpToDrop()` hook.

The NeoForge update to `.113-beta` is required for this new event `BlockDropsEvent` addition, and the NeoGradle update is required for NeoForge versions `.112-beta` and above.