### PR TITLE
Support `Inventory.contains(Predicate<ItemStack>)`

### DIFF
--- a/neoforge/src/main/java/top/theillusivec4/curios/mixin/CuriosUtilMixinHooks.java
+++ b/neoforge/src/main/java/top/theillusivec4/curios/mixin/CuriosUtilMixinHooks.java
@@ -25,6 +25,7 @@ import com.mojang.datafixers.schemas.Schema;
 import com.mojang.datafixers.types.templates.TypeTemplate;
 import com.mojang.datafixers.util.Pair;
 import java.util.Map;
+import java.util.function.Predicate;
 import net.minecraft.core.NonNullList;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -183,6 +184,11 @@ public class CuriosUtilMixinHooks {
   public static boolean containsTag(Player player, TagKey<Item> tagKey) {
     return CuriosApi.getCuriosInventory(player).map(
             inv -> inv.findFirstCurio(stack2 -> !stack2.isEmpty() && stack2.is(tagKey)).isPresent())
+        .orElse(false);
+  }
+
+  public static boolean containsPredicate(Player player, Predicate<ItemStack> predicate) {
+    return CuriosApi.getCuriosInventory(player).map(inv -> inv.findFirstCurio(predicate).isPresent())
         .orElse(false);
   }
 }

--- a/neoforge/src/main/java/top/theillusivec4/curios/mixin/CuriosUtilMixinHooks.java
+++ b/neoforge/src/main/java/top/theillusivec4/curios/mixin/CuriosUtilMixinHooks.java
@@ -176,19 +176,18 @@ public class CuriosUtilMixinHooks {
   }
 
   public static boolean containsStack(Player player, ItemStack stack) {
-    return CuriosApi.getCuriosInventory(player).map(inv -> inv.findFirstCurio(
-            stack2 -> !stack2.isEmpty() && ItemStack.isSameItemSameComponents(stack, stack2))
-        .isPresent()).orElse(false);
+    return CuriosApi.getCuriosInventory(player).flatMap(inv -> inv.findFirstCurio(
+            stack2 -> !stack2.isEmpty() && ItemStack.isSameItemSameComponents(stack, stack2)))
+        .isPresent();
   }
 
   public static boolean containsTag(Player player, TagKey<Item> tagKey) {
-    return CuriosApi.getCuriosInventory(player).map(
-            inv -> inv.findFirstCurio(stack2 -> !stack2.isEmpty() && stack2.is(tagKey)).isPresent())
-        .orElse(false);
+    return CuriosApi.getCuriosInventory(player).flatMap(
+            inv -> inv.findFirstCurio(stack2 -> !stack2.isEmpty() && stack2.is(tagKey)))
+        .isPresent();
   }
 
-  public static boolean containsPredicate(Player player, Predicate<ItemStack> predicate) {
-    return CuriosApi.getCuriosInventory(player).map(inv -> inv.findFirstCurio(predicate).isPresent())
-        .orElse(false);
+  public static boolean contains(Player player, Predicate<ItemStack> predicate) {
+    return CuriosApi.getCuriosInventory(player).flatMap(inv -> inv.findFirstCurio(predicate)).isPresent();
   }
 }

--- a/neoforge/src/main/java/top/theillusivec4/curios/mixin/core/MixinInventory.java
+++ b/neoforge/src/main/java/top/theillusivec4/curios/mixin/core/MixinInventory.java
@@ -20,6 +20,7 @@
 
 package top.theillusivec4.curios.mixin.core;
 
+import java.util.function.Predicate;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -59,6 +60,18 @@ public class MixinInventory {
   private void curios$containsTag(TagKey<Item> tagKey, CallbackInfoReturnable<Boolean> cir) {
 
     if (CuriosUtilMixinHooks.containsTag(this.player, tagKey)) {
+      cir.setReturnValue(true);
+    }
+  }
+
+  @Inject(
+          at = @At("TAIL"),
+          method = "contains(Ljava/util/function/Predicate;)Z",
+          cancellable = true
+  )
+  private void curios$containsPredicate(Predicate<ItemStack> predicate, CallbackInfoReturnable<Boolean> cir) {
+
+    if (CuriosUtilMixinHooks.containsPredicate(this.player, predicate)) {
       cir.setReturnValue(true);
     }
   }

--- a/neoforge/src/main/java/top/theillusivec4/curios/mixin/core/MixinInventory.java
+++ b/neoforge/src/main/java/top/theillusivec4/curios/mixin/core/MixinInventory.java
@@ -69,9 +69,9 @@ public class MixinInventory {
           method = "contains(Ljava/util/function/Predicate;)Z",
           cancellable = true
   )
-  private void curios$containsPredicate(Predicate<ItemStack> predicate, CallbackInfoReturnable<Boolean> cir) {
+  private void curios$contains(Predicate<ItemStack> predicate, CallbackInfoReturnable<Boolean> cir) {
 
-    if (CuriosUtilMixinHooks.containsPredicate(this.player, predicate)) {
+    if (CuriosUtilMixinHooks.contains(this.player, predicate)) {
       cir.setReturnValue(true);
     }
   }


### PR DESCRIPTION
This adds support for the third `Inventory.contains` method, one that I happened to use for Ok Zoomer's Spyglass Mode.

While I have realized that predicates wouldn't be necessary and that I could just use a tag, it is only the case because of the absence of client tags in NeoForge. Therefore, I consider this PR to be important for third-party support without any extra effort on the other mod's side

PS: Please let me know if it's feasible to backport this to Curios 1.20.1; I could attempt a second PR but I might not be as reliable for that