### PR TITLE
[1.20.1] Concurrent modification spam

### DIFF
--- a/src/main/java/top/theillusivec4/curios/common/inventory/CurioStacksHandler.java
+++ b/src/main/java/top/theillusivec4/curios/common/inventory/CurioStacksHandler.java
@@ -171,10 +171,10 @@ public class CurioStacksHandler implements ICurioStacksHandler {
     AttributeModifier newModifier =
         new AttributeModifier(LEGACY_UUID, "legacy", current, AttributeModifier.Operation.ADDITION);
     this.modifiers.put(newModifier.getId(), newModifier);
-    Collection<AttributeModifier> modifiers =
-        this.getModifiersByOperation(newModifier.getOperation());
-    modifiers.remove(newModifier);
-    modifiers.add(newModifier);
+    synchronized (this.modifiersByOperation) {
+      this.modifiersByOperation.remove(newModifier.getOperation(), newModifier);
+      this.modifiersByOperation.put(newModifier.getOperation(), newModifier);
+    }
     this.persistentModifiers.remove(newModifier);
     this.persistentModifiers.add(newModifier);
     this.flagUpdate();
@@ -437,12 +437,16 @@ public class CurioStacksHandler implements ICurioStacksHandler {
 
   public Collection<AttributeModifier> getModifiersByOperation(
       AttributeModifier.Operation operation) {
-    return this.modifiersByOperation.get(operation);
+    synchronized (this.modifiersByOperation) {
+      return new ArrayList<>(this.modifiersByOperation.get(operation));
+    }
   }
 
   public void addTransientModifier(AttributeModifier modifier) {
     this.modifiers.put(modifier.getId(), modifier);
-    this.getModifiersByOperation(modifier.getOperation()).add(modifier);
+    synchronized (this.modifiersByOperation) {
+      this.modifiersByOperation.put(modifier.getOperation(), modifier);
+    }
     this.flagUpdate();
   }
 
@@ -456,7 +460,9 @@ public class CurioStacksHandler implements ICurioStacksHandler {
 
     if (modifier != null) {
       this.persistentModifiers.remove(modifier);
-      this.getModifiersByOperation(modifier.getOperation()).remove(modifier);
+      synchronized (this.modifiersByOperation) {
+        this.modifiersByOperation.remove(modifier.getOperation(), modifier);
+      }
       this.flagUpdate();
     }
   }


### PR DESCRIPTION
That's probably more of a suggestion since no one has complained yet.

I am honestly very confused by this, but some of our player have their log spammed with this. When I try to replicate their environment, it's all fine for me, even in multiplayer, so can't even provide any steps to reproduce that
```
[22:17:08] [CullThread/INFO]: [dev.tr7zw.entityculling.CullTask:run:86]: java.util.ConcurrentModificationException
[22:17:08] [CullThread/INFO]: [dev.tr7zw.entityculling.CullTask:run:86]: 	at java.base/java.util.HashMap$HashIterator.nextNode(Unknown Source)
[22:17:08] [CullThread/INFO]: [dev.tr7zw.entityculling.CullTask:run:86]: 	at java.base/java.util.HashMap$KeyIterator.next(Unknown Source)
[22:17:08] [CullThread/INFO]: [dev.tr7zw.entityculling.CullTask:run:86]: 	at MC-BOOTSTRAP/com.google.common@31.1-jre/com.google.common.collect.AbstractMapBasedMultimap$WrappedCollection$WrappedIterator.next(AbstractMapBasedMultimap.java:473)
[22:17:08] [CullThread/INFO]: [dev.tr7zw.entityculling.CullTask:run:86]: 	at TRANSFORMER/curios@5.14.1+1.20.1/top.theillusivec4.curios.common.inventory.CurioStacksHandler.update(CurioStacksHandler.java:496)
[22:17:08] [CullThread/INFO]: [dev.tr7zw.entityculling.CullTask:run:86]: 	at TRANSFORMER/curios@5.14.1+1.20.1/top.theillusivec4.curios.common.inventory.CurioStacksHandler.getStacks(CurioStacksHandler.java:102)
[22:17:08] [CullThread/INFO]: [dev.tr7zw.entityculling.CullTask:run:86]: 	at TRANSFORMER/curios@5.14.1+1.20.1/top.theillusivec4.curios.common.capability.CurioInventoryCapability$CurioInventoryWrapper.findFirstCurio(CurioInventoryCapability.java:183)
[22:17:08] [CullThread/INFO]: [dev.tr7zw.entityculling.CullTask:run:86]: 	at TRANSFORMER/curios@5.14.1+1.20.1/top.theillusivec4.curios.common.capability.CurioInventoryCapability$CurioInventoryWrapper.findFirstCurio(CurioInventoryCapability.java:174)
[22:17:08] [CullThread/INFO]: [dev.tr7zw.entityculling.CullTask:run:86]: 	at TRANSFORMER/irons_spellbooks@1.20.1-3.15.3/io.redspace.ironsspellbooks.item.curios.CurioBaseItem.lambda$isEquippedBy$0(CurioBaseItem.java:32)
[22:17:08] [CullThread/INFO]: [dev.tr7zw.entityculling.CullTask:run:86]: 	at TRANSFORMER/forge@47.4.16/net.minecraftforge.common.util.LazyOptional.map(LazyOptional.java:180)
[22:17:08] [CullThread/INFO]: [dev.tr7zw.entityculling.CullTask:run:86]: 	at TRANSFORMER/irons_spellbooks@1.20.1-3.15.3/io.redspace.ironsspellbooks.item.curios.CurioBaseItem.isEquippedBy(CurioBaseItem.java:32)
[22:17:08] [CullThread/INFO]: [dev.tr7zw.entityculling.CullTask:run:86]: 	at TRANSFORMER/minecraft@1.20.1/net.minecraft.world.entity.Entity.handler$hep000$isInvisibleTo(Entity.java:22104)
[22:17:08] [CullThread/INFO]: [dev.tr7zw.entityculling.CullTask:run:86]: 	at TRANSFORMER/minecraft@1.20.1/net.minecraft.world.entity.Entity.m_20177_(Entity.java)
[22:17:08] [CullThread/INFO]: [dev.tr7zw.entityculling.CullTask:run:86]: 	at TRANSFORMER/l2hostility@2.5.17/dev.xkmc.l2hostility.events.ClientGlowingHandler.isGlowingImpl(ClientGlowingHandler.java:56)
[22:17:08] [CullThread/INFO]: [dev.tr7zw.entityculling.CullTask:run:86]: 	at TRANSFORMER/l2hostility@2.5.17/dev.xkmc.l2hostility.events.ClientGlowingHandler.isGlowing(ClientGlowingHandler.java:32)
[22:17:08] [CullThread/INFO]: [dev.tr7zw.entityculling.CullTask:run:86]: 	at TRANSFORMER/minecraft@1.20.1/net.minecraft.world.entity.Entity.handler$ghp000$l2hostility$isGlowing(Entity.java:20590)
[22:17:08] [CullThread/INFO]: [dev.tr7zw.entityculling.CullTask:run:86]: 	at TRANSFORMER/minecraft@1.20.1/net.minecraft.world.entity.Entity.m_142038_(Entity.java)
[22:17:08] [CullThread/INFO]: [dev.tr7zw.entityculling.CullTask:run:86]: 	at TRANSFORMER/minecraft@1.20.1/net.minecraft.world.entity.LivingEntity.m_142038_(LivingEntity.java:3438)
[22:17:08] [CullThread/INFO]: [dev.tr7zw.entityculling.CullTask:run:86]: 	at TRANSFORMER/minecraft@1.20.1/net.minecraft.client.Minecraft.m_91314_(Minecraft.java:2536)
[22:17:08] [CullThread/INFO]: [dev.tr7zw.entityculling.CullTask:run:86]: 	at TRANSFORMER/entityculling@1.9.5/dev.tr7zw.entityculling.CullTask.cullEntities(CullTask.java:117)
[22:17:08] [CullThread/INFO]: [dev.tr7zw.entityculling.CullTask:run:86]: 	at TRANSFORMER/entityculling@1.9.5/dev.tr7zw.entityculling.CullTask.run(CullTask.java:79)
[22:17:08] [CullThread/INFO]: [dev.tr7zw.entityculling.CullTask:run:86]: 	at java.base/java.lang.Thread.run(Unknown Source)
```

[latest.log](https://github.com/user-attachments/files/25945289/latest.log)
