### PR TITLE
Fix Turkish-locale casing bug in slot type id

### DIFF
--- a/src/main/java/top/theillusivec4/curios/api/CuriosSlotTypes.java
+++ b/src/main/java/top/theillusivec4/curios/api/CuriosSlotTypes.java
@@ -1,5 +1,6 @@
 package top.theillusivec4.curios.api;
 
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiPredicate;
@@ -125,7 +126,7 @@ public final class CuriosSlotTypes {
     RING;
 
     public String id() {
-      return this.toString().toLowerCase();
+      return this.toString().toLowerCase(Locale.ROOT);
     }
   }
 }


### PR DESCRIPTION
Fixes #611.

`Preset.id()` calls `toString().toLowerCase()` with no locale, so it uses whatever locale the JVM is running under. On a Turkish locale (`-Duser.language=tr -Duser.country=TR`), `toLowerCase()` turns `I` into a dotless `ı` (U+0131) instead of `i`. That turns `CURIO` into `curıo`, which isn't a valid resource path, and the game crashes on startup building `CuriosTags`.

Switched it to `toLowerCase(Locale.ROOT)` so the id is locale-independent.

I only touched this one call site since it's the one in the crash trace. There are a few other `toLowerCase()`/`toUpperCase()` calls elsewhere in the codebase (`DropRule`, `SlotType`, `CurioSlot`, `SlotData`, `CuriosClientEvents`) that take the same risk if the input string ever contains a locale-sensitive letter. Left them out of this PR to keep the diff focused, but flagging them here in case a follow-up sweep is worth doing.

Couldn't run a full build locally (NeoForge/Gradle toolchain), so this hasn't been tested in a running game. The change itself is a one-line locale fix with well-defined behavior, but wanted to be upfront about that.
