### PR TITLE
Fix invalid placeholder in Turkish add.success command message

### DIFF
--- a/src/main/resources/assets/curios/lang/tr_tr.json
+++ b/src/main/resources/assets/curios/lang/tr_tr.json
@@ -4,7 +4,7 @@
   "curios.tooltip.slot": "Yuva:",
   "curios.cosmetic": "Kozmetik",
   "commands.curios.set.success": "Tür %s şimdi %s yuvalara ayarlandı. %s için",
-  "commands.curios.add.success": "%s türünde &d yuvalar, %s'e eklendi",
+  "commands.curios.add.success": "%s türünde %d yuvalar, %s'e eklendi",
   "commands.curios.remove.success": "%s türünde %d yuvalar, %s'den kaldırıldı",
   "commands.curios.unlock.success": "Yuva %s, %s için açıldı",
   "commands.curios.lock.success": "Yuva %s, %s için kilitlendi",


### PR DESCRIPTION
`commands.curios.add.success` in `tr_tr.json` has `&d` instead of `%d`:

```
"%s türünde &d yuvalar, %s'e eklendi"
```

`&d` isn't a valid Java `Formatter` conversion, so this either throws `UnknownFormatConversionException` or prints the literal characters `&d` instead of the slot count when the command runs. The sibling key right below it, `commands.curios.remove.success`, has the identical grammatical slot using `%d`:

```
"%s türünde %d yuvalar, %s'den kaldırıldı"
```

and `en_us.json` confirms that position is the slot count (`%d slots of type %s...`). One-character typo, fixed to `%d`.
