### PR TITLE
fix: use renderTooltip method that accounts for the ItemStack

### DIFF
--- a/neoforge/src/main/java/top/theillusivec4/curios/client/gui/CuriosScreen.java
+++ b/neoforge/src/main/java/top/theillusivec4/curios/client/gui/CuriosScreen.java
@@ -325,8 +325,8 @@ public class CuriosScreen extends EffectRenderingInventoryScreen<CuriosContainer
               components.add(
                   Component.translatable("curios.tooltip.inactive").withStyle(ChatFormatting.RED));
             }
-            guiGraphics.renderTooltip(this.font, components, stack.getTooltipImage(), mouseX,
-                                      mouseY);
+            guiGraphics.renderTooltip(this.font, components, stack.getTooltipImage(), stack,
+                                      mouseX, mouseY);
           }
         }
       }


### PR DESCRIPTION
This fix passes the actual hovered stack through to renderTooltip, matching what vanilla's AbstractContainerScreen#renderTooltip does.

This restores the correct ItemStack context for the tooltip event pipeline, so AppleSkin (and any other mod hooking GatherComponents/ItemTooltipEvent) can now modify tooltips for items shown in Curios slots.
