### PR TITLE
Fix memory leak: ServerPlayer not released on logout

### DIFF
--- a/src/main/java/top/theillusivec4/curios/common/event/CuriosEventHandler.java
+++ b/src/main/java/top/theillusivec4/curios/common/event/CuriosEventHandler.java
@@ -68,6 +68,7 @@ import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.event.entity.living.LootingLevelEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent.PlayerLoggedInEvent;
+import net.minecraftforge.event.entity.player.PlayerEvent.PlayerLoggedOutEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.entity.player.PlayerXpEvent.PickupXp;
 import net.minecraftforge.event.level.BlockEvent;
@@ -187,6 +188,15 @@ public class CuriosEventHandler {
       }
     }
     return false;
+  }
+
+  @SubscribeEvent
+  public void playerLoggedOut(PlayerLoggedOutEvent evt) {
+    Player player = evt.getEntity();
+
+    if (player != null) {
+      player.getCapability(CuriosCapability.ID_INVENTORY).invalidate();
+    }
   }
 
   @SubscribeEvent


### PR DESCRIPTION
As described in #628, when a player logs out, ServerPlayer objects remain
strongly reachable because CurioInventoryWrapper holds a "wearer" reference
that is never cleaned up, retaining all referenced LevelChunk as well.

The issue is that CuriosEventHandler has no handler for
PlayerEvent.PlayerLoggedOutEvent. This PR adds one that invalidates
the curio inventory capability on logout, breaking the reference chain.

Detection: AllTheLeaks (48 ServerPlayer, 2350 LevelChunk), confirmed by
Eclipse MAT heap dump analysis.